### PR TITLE
test satellites

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,50 +6,18 @@ on:
 
 jobs:
   ci:
-    needs: [test, build, fmt, lint, cargo-deny]
     runs-on: ubuntu-latest
-    steps:
-      - shell: bash
-        run: |
-          echo "Build success"
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: earthly/actions-setup@v1
-        with:
-          version: v0.7.15
-      - uses: actions/checkout@v3
-      - name: Run Tests
-        run: earthly --ci +run-tests
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: earthly/actions-setup@v1
-        with:
-          version: v0.7.15
-      - uses: actions/checkout@v3
-      - name: Build crate
-        run: earthly --ci +build-release
-  fmt:
-    runs-on: ubuntu-latest
+    environment: earthly_visit_temp
     env:
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
       FORCE_COLOR: 1
     steps:
       - uses: earthly/actions-setup@v1
         with:
-          version: v0.7.15
+          version: v0.7.17
       - uses: actions/checkout@v3
-      - name: Check code formatting
-        run: earthly --ci +fmt
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: earthly/actions-setup@v1
-        with:
-          version: v0.7.15
-      - uses: actions/checkout@v3
-      - name: Lint crate
-        run: earthly --ci +lint
+      - name: Run +ci on earthly satellites
+        run: earthly --org expressvpn --satellite wolfssl --ci +ci
   cargo-deny:
     runs-on: ubuntu-latest
     steps:

--- a/Earthfile
+++ b/Earthfile
@@ -1,32 +1,37 @@
 VERSION 0.7
+IMPORT github.com/earthly/lib/rust:2.1.0 AS rust
+
 FROM rust:1.72
 
-WORKDIR /wolfssl-sys
+WORKDIR /wolfssl
 
 build-deps:
     RUN apt-get update -qq
     RUN apt-get install --no-install-recommends -qq autoconf autotools-dev libtool-bin clang cmake
     RUN apt-get -y install --no-install-recommends bsdmainutils
+    RUN cargo install --locked cargo-deny
     RUN rustup component add rustfmt
+    RUN rustup component add clippy
 
 copy-src:
     FROM +build-deps
     COPY Cargo.toml Cargo.lock ./
+    COPY deny.toml ./
     COPY --dir src tests ./
 
 build-dev:
     FROM +copy-src
-    RUN cargo build
+    DO rust+CARGO --args="build"
     SAVE ARTIFACT target/debug /debug AS LOCAL artifacts/debug
 
 build-release:
     FROM +copy-src
-    RUN cargo build --release
+    DO rust+CARGO --args="build --release"
     SAVE ARTIFACT target/release /release AS LOCAL artifacts/release
 
 run-tests:
     FROM +copy-src
-    RUN cargo test
+    DO rust+CARGO --args="test"
 
 build:
     BUILD +run-tests
@@ -34,20 +39,24 @@ build:
 
 build-crate:
     FROM +copy-src
-    RUN cargo package
+    DO rust+CARGO --args="package"
     SAVE ARTIFACT target/package/*.crate /package/ AS LOCAL artifacts/crate/
 
 lint:
     FROM +copy-src
-    RUN rustup component add clippy
-    RUN cargo clippy --all-features --all-targets -- -D warnings
+    DO rust+CARGO --args="clippy --all-features --all-targets -- -D warnings"
 
 fmt:
     FROM +copy-src
-    RUN rustup component add rustfmt
-    RUN cargo fmt --check
+    DO rust+CARGO --args="fmt --check"
+
+ci:
+    BUILD +run-tests
+    BUILD +build-release
+    BUILD +lint
+    BUILD +fmt
+    BUILD +check-license
 
 check-license:
-    RUN cargo install --locked cargo-deny
-    COPY --dir src tests Cargo.toml Cargo.lock deny.toml ./
-    RUN cargo deny --all-features check bans license sources
+    FROM +copy-src
+    DO rust+CARGO --args="deny --all-features check bans license sources"


### PR DESCRIPTION
This PR:
- Collapses the Earthly targets run on `ci.yaml` into a new `+ci` target, so only one GH runner is needed for them
- Makes use of https://github.com/earthly/lib/blob/main/rust/Earthfile#L10 to cache cargo dependency downloads and compilations across builds
- Runs earthly in a dedicated satellite, so cache is maintained across different GH action runs

As a result, this PR reduces GH actions build time from around 8m to 50s for the most likely scenario of only source code changing