### PR TITLE
LIT-122: Speed up builds using Earthly Satellite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ci:
-    needs: [test, build, fmt, lint, coverage, cargo-deny]
+    needs: [test, build, fmt, lint, coverage, check-dependencies]
     runs-on: ubuntu-latest
     steps:
       - shell: bash
@@ -124,7 +124,7 @@ jobs:
           submodules: true
       - name: Run +lint on Earthly satellite
         run: earthly --ci --org expressvpn --satellite wolfssl-rs +lint
-  cargo-deny:
+  check-dependencies:
     runs-on: ubuntu-latest
     environment: earthly_visit_temp
     env:
@@ -137,5 +137,5 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Run +check-license on Earthly satellite
-        run: earthly --ci --org expressvpn --satellite wolfssl-rs +check-license
+      - name: Run +check-dependencies on Earthly satellite
+        run: earthly --ci --org expressvpn --satellite wolfssl-rs +check-dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,18 +14,9 @@ jobs:
           echo "Build success"
   test:
     runs-on: ubuntu-latest
-    steps:
-      - uses: earthly/actions-setup@v1
-        with:
-          version: v0.7.15
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Run Tests
-        run: earthly --ci +run-tests
-  coverage:
-    runs-on: ubuntu-latest
+    environment: earthly_visit_temp
     env:
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
       FORCE_COLOR: 1
     steps:
       - uses: earthly/actions-setup@v1
@@ -34,10 +25,25 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Run Coverage
+      - name: +run-tests on Earthly satellite
+        run: earthly --ci --org expressvpn --satellite wolfssl-rs +run-tests
+  coverage:
+    runs-on: ubuntu-latest
+    environment: earthly_visit_temp
+    env:
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      FORCE_COLOR: 1
+    steps:
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.7.19
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: +run-coverage on Earthly satellite
         id: coverage
         run: |
-          earthly --ci --artifact +run-coverage/* output/
+          earthly --ci --org expressvpn --satellite wolfssl-rs --artifact +run-coverage/* output/
 
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "summary<<$EOF"    >> "$GITHUB_OUTPUT"
@@ -75,45 +81,61 @@ jobs:
           edit-mode: replace
   build:
     runs-on: ubuntu-latest
-    steps:
-      - uses: earthly/actions-setup@v1
-        with:
-          version: v0.7.15
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Build crate
-        run: earthly --ci +build-release
-  fmt:
-    runs-on: ubuntu-latest
+    environment: earthly_visit_temp
     env:
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
       FORCE_COLOR: 1
     steps:
       - uses: earthly/actions-setup@v1
         with:
-          version: v0.7.15
+          version: v0.7.19
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Check code formatting
-        run: earthly --ci +fmt
-  lint:
+      - name: Run +build-release on Earthly satellite
+        run: earthly --ci --org expressvpn --satellite wolfssl-rs +build-release
+  fmt:
     runs-on: ubuntu-latest
+    environment: earthly_visit_temp
+    env:
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      FORCE_COLOR: 1
     steps:
       - uses: earthly/actions-setup@v1
         with:
-          version: v0.7.15
+          version: v0.7.19
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Lint crate
-        run: earthly --ci +lint
+      - name: Run +fmt on Earthly satellite
+        run: earthly --ci --org expressvpn --satellite wolfssl-rs +fmt
+  lint:
+    runs-on: ubuntu-latest
+    environment: earthly_visit_temp
+    env:
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      FORCE_COLOR: 1
+    steps:
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.7.19
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Run +lint on Earthly satellite
+        run: earthly --ci --org expressvpn --satellite wolfssl-rs +lint
   cargo-deny:
     runs-on: ubuntu-latest
+    environment: earthly_visit_temp
+    env:
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+      FORCE_COLOR: 1
     steps:
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.7.19
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: EmbarkStudios/cargo-deny-action@v1
-        with:
-          command: check bans licenses sources
+      - name: Run +check-license on Earthly satellite
+        run: earthly --ci --org expressvpn --satellite wolfssl-rs +check-license

--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,7 @@
 VERSION 0.7
+# Importing https://github.com/earthly/lib/tree/2.2.1/rust via commit hash pinning becuase git tags can be changed
+IMPORT github.com/earthly/lib/rust:794f789da87fc638cd322e9b60f82ad896282fb3 AS rust-udc
+
 FROM rust:1.72.1
 
 WORKDIR /wolfssl-rs
@@ -17,26 +20,26 @@ copy-src:
 
 build-dev:
     FROM +copy-src
-    RUN cargo build
+    DO rust-udc+CARGO --args="build"
     SAVE ARTIFACT target/debug /debug AS LOCAL artifacts/debug
 
 build-release:
     FROM +copy-src
-    RUN cargo build --release
+    DO rust-udc+CARGO --args="build --release"
     SAVE ARTIFACT target/release /release AS LOCAL artifacts/release
 
 run-tests:
     FROM +copy-src
-    RUN cargo test
+    DO rust-udc+CARGO --args="test"
 
 run-coverage:
     FROM +copy-src
-    RUN cargo llvm-cov test
+    RUN rust-udc+CARGO --args="llvm-cov test"
 
     RUN mkdir /tmp/coverage
 
-    RUN cargo llvm-cov report --summary-only --output-path /tmp/coverage/summary.txt
-    RUN cargo llvm-cov report --html --output-dir /tmp/coverage/
+    RUN rust-udc+CARGO --args="llvm-cov report --summary-only --output-path /tmp/coverage/summary.txt"
+    RUN rust-udc+CARGO --args="llvm-cov report --html --output-dir /tmp/coverage/"
     SAVE ARTIFACT /tmp/coverage/*
 
 build:
@@ -45,17 +48,17 @@ build:
 
 build-crate:
     FROM +copy-src
-    RUN cargo package
+    DO rust-udc+CARGO --args="package"
     SAVE ARTIFACT target/package/*.crate /package/ AS LOCAL artifacts/crate/
 
 lint:
     FROM +copy-src
-    RUN cargo clippy --all-features --all-targets -- -D warnings
+    DO rust-udc+CARGO --args="clippy --all-features --all-targets -- -D warnings"
 
 fmt:
     FROM +copy-src
-    RUN cargo fmt --check
+    DO rust-udc+CARGO --args="fmt --check"
 
 check-license:
     FROM +copy-src
-    RUN cargo deny --all-features check bans license sources
+    DO rust-udc+CARGO --args="deny --all-features check bans license sources"

--- a/Earthfile
+++ b/Earthfile
@@ -34,12 +34,12 @@ run-tests:
 
 run-coverage:
     FROM +copy-src
-    RUN rust-udc+CARGO --args="llvm-cov test"
+    DO rust-udc+CARGO --args="llvm-cov test"
 
     RUN mkdir /tmp/coverage
 
-    RUN rust-udc+CARGO --args="llvm-cov report --summary-only --output-path /tmp/coverage/summary.txt"
-    RUN rust-udc+CARGO --args="llvm-cov report --html --output-dir /tmp/coverage/"
+    DO rust-udc+CARGO --args="llvm-cov report --summary-only --output-path /tmp/coverage/summary.txt"
+    DO rust-udc+CARGO --args="llvm-cov report --html --output-dir /tmp/coverage/"
     SAVE ARTIFACT /tmp/coverage/*
 
 build:

--- a/Earthfile
+++ b/Earthfile
@@ -59,6 +59,6 @@ fmt:
     FROM +copy-src
     DO rust-udc+CARGO --args="fmt --check"
 
-check-license:
+check-dependencies:
     FROM +copy-src
     DO rust-udc+CARGO --args="deny --all-features check bans license sources"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ So we built one :)
 
 # Building and Running
 
+After cloning this repo, you'll also need to clone the submodules for the WolfSSL source code via:
+```
+git submodule update --init
+```
+
 Currently, the usual commands from `cargo` works perfectly fine. Common commands
 include the following:
 

--- a/README.md
+++ b/README.md
@@ -46,3 +46,11 @@ There is also an `Earthfile` provided so that you can build the crate in [Earthl
 ```
 earthly +build-crate
 ```
+## Speeding up development with Earthly Satellites
+
+Please refer to [official documentation for Earthly Satellites](https://docs.earthly.dev/earthly-cloud/satellites).
+
+If you are a member of ExpressVPN, you can get access to the same Earthly organization used in our CI. The organization is named `expressvpn`, inside which contains a satellite named `wolfssl-rs`.
+
+If you are not a member of ExpressVPN, you may set up your own Earthly satellite according the official instructions above.
+ 


### PR DESCRIPTION
This PR reduces GH actions build time from around 8m to 50s for the most likely scenario of only source code changing.

It takes @idelvall's changes from https://github.com/expressvpn/wolfssl-rs/pull/23 and rebases it onto the latest master with some cosmetic changes.

To do once this PR is approved:
- [x] Clean up old `wolfssl` satelliete because we're now using a satellite named `wolfssl-rs` .  Clean up the satellite named `+build` while we're at it