### PR TITLE
LIT-122: Add support for `earthly doc`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: +run-tests on Earthly satellite
+      - name: Run +run-tests on Earthly satellite
         run: earthly --ci --org expressvpn --satellite wolfssl-rs +run-tests
   coverage:
     runs-on: ubuntu-latest
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: +run-coverage on Earthly satellite
+      - name: Run +run-coverage on Earthly satellite
         id: coverage
         run: |
           earthly --ci --org expressvpn --satellite wolfssl-rs --artifact +run-coverage/* output/

--- a/Earthfile
+++ b/Earthfile
@@ -18,20 +18,24 @@ copy-src:
     FROM +build-deps
     COPY --dir Cargo.toml Cargo.lock deny.toml wolfssl wolfssl-sys ./
 
+# build-dev builds with the Cargo dev profile and produces debug artifacts
 build-dev:
     FROM +copy-src
     DO rust-udc+CARGO --args="build"
     SAVE ARTIFACT target/debug /debug AS LOCAL artifacts/debug
 
+# build-release builds with the Cargo release profile and produces release artifacts
 build-release:
     FROM +copy-src
     DO rust-udc+CARGO --args="build --release"
     SAVE ARTIFACT target/release /release AS LOCAL artifacts/release
 
+# run-tests executes all unit and integration tests via Cargo
 run-tests:
     FROM +copy-src
     DO rust-udc+CARGO --args="test"
 
+# run-coverage generates a report of code coverage by unit and integration tests via cargo-llvm-cov
 run-coverage:
     FROM +copy-src
     DO rust-udc+CARGO --args="llvm-cov test"
@@ -42,23 +46,28 @@ run-coverage:
     DO rust-udc+CARGO --args="llvm-cov report --html --output-dir /tmp/coverage/"
     SAVE ARTIFACT /tmp/coverage/*
 
+# build runs tests and then creates a release build
 build:
     BUILD +run-tests
     BUILD +build-release
 
+# build-crate creates a .crate file for distribution of source code
 build-crate:
     FROM +copy-src
     DO rust-udc+CARGO --args="package"
     SAVE ARTIFACT target/package/*.crate /package/ AS LOCAL artifacts/crate/
 
+# lint runs cargo clippy on the source code
 lint:
     FROM +copy-src
     DO rust-udc+CARGO --args="clippy --all-features --all-targets -- -D warnings"
 
+# fmt checks whether Rust code is formatted according to style guidelines
 fmt:
     FROM +copy-src
     DO rust-udc+CARGO --args="fmt --check"
 
+# check-dependencies lints our dependencies via cargo-deny
 check-dependencies:
     FROM +copy-src
     DO rust-udc+CARGO --args="deny --all-features check bans license sources"

--- a/README.md
+++ b/README.md
@@ -41,10 +41,15 @@ cargo clippy
 ```
 
 ## Building with Earthly
-There is also an `Earthfile` provided so that you can build the crate in [Earthly](https://earthly.dev):
+There is also an `Earthfile` provided.  For example, here's how you can build the crate in [Earthly](https://earthly.dev):
 
 ```
 earthly +build-crate
+```
+
+For more information about the different Earthly targets available, run:
+```
+earthly doc
 ```
 ## Speeding up development with Earthly Satellites
 


### PR DESCRIPTION
Here's what it looks like!

```
$ earthly doc
TARGETS:
  +build-dev
      build-dev builds with the Cargo dev profile and produces debug artifacts
  +build-release
      build-release builds with the Cargo release profile and produces release artifacts
  +run-tests
      run-tests executes all unit and integration tests via Cargo
  +run-coverage
      run-coverage generates a report of code coverage by unit and integration tests
  +build
      build runs tests and then creates a release build
  +lint
      lint runs cargo clippy on the ssource code
  +fmt
      fmt formats Rust code according to style guidelines
  +check-dependencies
      check-dependencies lints our dependencies
```