### PR TITLE
GHA: Ensure coverage job updates a single comment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
         with:
           issue-number: ${{ steps.find-pr.outputs.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: 'Code coverage summary:'
+          body-includes: 'Code coverage summary'
       - name: Create or update comment
         if: steps.find-pr.outputs.number
         uses: peter-evans/create-or-update-comment@v3


### PR DESCRIPTION
A last minute change to 4f081570d31a ("GHA: Run coverage during CI") changed the comment message (to add a link) such that `peter-evans/find-comment@v2` no longer matched the body text.