### PR TITLE
wolfssl-sys: Bump to bindgen 0.68.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.4.0",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.37",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,7 +387,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fa114149fb6e5362b9cf539de9305a6a3cf1556fbfa93b5053b4f70cf3adfb9"
 dependencies = [
- "bindgen",
+ "bindgen 0.65.1",
  "build-deps",
  "cmake",
  "libc",
@@ -806,7 +829,7 @@ name = "wolfssl-sys"
 version = "0.1.15"
 dependencies = [
  "autotools",
- "bindgen",
+ "bindgen 0.68.1",
  "build-target",
  "oqs-sys",
 ]

--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["wolfssl", "vpn", "lightway", "post-quantum", "cryptography"]
 links = "wolfssl"
 
 [build-dependencies]
-bindgen = "0.65"
+bindgen = "0.68"
 autotools = "0.2"
 build-target = "0.4.0"
 


### PR DESCRIPTION
https://github.com/rust-lang/rust-bindgen/compare/v0.65.1...v0.68.1

---

https://github.com/expressvpn/wolfssl-rs/actions/runs/6401913884/job/17377704752 was the weekly job which failed to highlight this, it actually failed for a couple of weeks.

Interesting bit of the upstream diff might be the changelog diff: https://github.com/rust-lang/rust-bindgen/compare/v0.65.1...v0.68.1#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR191

<details>
  <summary>The actual changes to generated `bindings.rs` are pretty dull</summary>

```diff
--- ./target/debug/build/wolfssl-sys-5299f67980159668/out/bindings.rs	2023-10-06 10:13:20.597765791 +0100
+++ /home/ianc/Development/lightway/orga-expressvpn/wolfssl-rs/./target/debug/build/wolfssl-sys-fcda466f0ea2d668/out/bindings.rs	2023-10-09 10:01:55.120865345 +0100
@@ -1,4 +1,4 @@
-/* automatically generated by rust-bindgen 0.65.1 */
+/* automatically generated by rust-bindgen 0.68.1 */
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -111,7 +111,7 @@
 pub const INVALID_DEVID: i32 = -2;
 pub const TRUE: u32 = 1;
 pub const FALSE: u32 = 0;
-pub const LIBWOLFSSL_VERSION_STRING: &[u8; 6usize] = b"5.6.3\0";
+pub const LIBWOLFSSL_VERSION_STRING: &[u8; 6] = b"5.6.3\0";
 pub const LIBWOLFSSL_VERSION_HEX: u32 = 83910659;
 pub const RNG_MAX_BLOCK_LEN: u32 = 65536;
 pub const DRBG_SEED_LEN: u32 = 55;
@@ -123,7 +123,7 @@
 pub const ASN_MAX_DEPTH: u32 = 16;
 pub const WC_HMAC_INNER_HASH_KEYED_SW: u32 = 1;
 pub const WC_HMAC_INNER_HASH_KEYED_DEV: u32 = 2;
-pub const WOLFSSL_VERSION: &[u8; 6usize] = b"5.6.3\0";
+pub const WOLFSSL_VERSION: &[u8; 6] = b"5.6.3\0";
 pub const SOCKET_EWOULDBLOCK: u32 = 11;
 pub const SOCKET_EAGAIN: u32 = 11;
 pub const SOCKET_ECONNRESET: u32 = 104;
@@ -172,7 +172,7 @@
 pub const WOLF_CRYPTO_EX_INDEX_UI_METHOD: u32 = 14;
 pub const WOLF_CRYPTO_EX_INDEX_DRBG: u32 = 15;
 pub const WOLF_CRYPTO_EX_INDEX__COUNT: u32 = 16;
-pub const WOLFSSL_DEFAULT_CIPHER_LIST: &[u8; 1usize] = b"\0";
+pub const WOLFSSL_DEFAULT_CIPHER_LIST: &[u8; 1] = b"\0";
 pub const WOLFSSL_CRL_MONITOR: u32 = 1;
 pub const WOLFSSL_CRL_START_MON: u32 = 2;
 pub const SSL2_VERSION: u32 = 2;
```  

</details>