### PR TITLE
deny.toml: Remove `allow-git` for liboqs

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,3 @@ external-default-features = "allow"
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = [
-  "https://github.com/open-quantum-safe/liboqs-rust",
-]


### PR DESCRIPTION
In 18884738310d ("wolfssl-sys: update liboqs to 0.8.0") we switched back to a released version.