### PR TITLE
Make `cargo deny`  warnings fatal

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -73,4 +73,4 @@ fmt:
 # check-dependencies lints our dependencies via cargo-deny
 check-dependencies:
     FROM +copy-src
-    DO rust-udc+CARGO --args="deny --all-features check bans license sources"
+    DO rust-udc+CARGO --args="deny --all-features check --deny warnings bans license sources"

--- a/deny.toml
+++ b/deny.toml
@@ -37,11 +37,15 @@ exceptions = [
 ignore = true
 
 [bans]
-multiple-versions = "warn"
+multiple-versions = "deny"
 wildcards = "allow"
 highlight = "all"
 workspace-default-features = "allow"
 external-default-features = "allow"
+skip = [
+    { name = "bindgen", version = "0.65.1" },
+    { name = "bitflags", version = "1.3.2" },
+]
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
The `cargo deny` check was passing but generating lots of warnings, one was fixed by #54, this addresses the remainder (which are due to duplicate versions) and then causes all warnings from `cargo deny` to become fatal in CI so we should catch any new ones.