### PR TITLE
Earthfile: Preserve timestamps on source code

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -16,7 +16,7 @@ build-deps:
 
 copy-src:
     FROM +build-deps
-    COPY --dir Cargo.toml Cargo.lock deny.toml wolfssl wolfssl-sys ./
+    COPY --keep-ts --dir Cargo.toml Cargo.lock deny.toml wolfssl wolfssl-sys ./
 
 # build-dev builds with the Cargo dev profile and produces debug artifacts
 build-dev:


### PR DESCRIPTION
`cargo` uses timestamps to decide when to rebuild things so it is important that they are reflected within the build container environment.