### PR TITLE
Update to new Earthly UDC

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,13 +6,17 @@ on:
 
 jobs:
   ci:
-    needs: [test, build, fmt, lint, coverage, check-dependencies]
+    needs: [earthly, coverage]
     runs-on: ubuntu-latest
     steps:
       - shell: bash
         run: |
           echo "Build success"
-  test:
+  earthly:
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [run-tests, build-release, fmt, lint, check-dependencies]
     runs-on: ubuntu-latest
     environment: earthly_visit_temp
     env:
@@ -25,8 +29,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Run +run-tests on Earthly satellite
-        run: earthly --ci --org expressvpn --satellite wolfssl-rs +run-tests
+      - name: Run +${{ matrix.target }} on Earthly satellite
+        run: earthly --ci --org expressvpn --satellite wolfssl-rs +${{ matrix.target }}
   coverage:
     runs-on: ubuntu-latest
     environment: earthly_visit_temp
@@ -127,63 +131,3 @@ jobs:
       - name: Coverage check fails
         if: steps.coverage-check.outputs.failed == 'true'
         run: exit 1
-  build:
-    runs-on: ubuntu-latest
-    environment: earthly_visit_temp
-    env:
-      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
-      FORCE_COLOR: 1
-    steps:
-      - uses: earthly/actions-setup@v1
-        with:
-          version: v0.7.20
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Run +build-release on Earthly satellite
-        run: earthly --ci --org expressvpn --satellite wolfssl-rs +build-release
-  fmt:
-    runs-on: ubuntu-latest
-    environment: earthly_visit_temp
-    env:
-      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
-      FORCE_COLOR: 1
-    steps:
-      - uses: earthly/actions-setup@v1
-        with:
-          version: v0.7.20
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Run +fmt on Earthly satellite
-        run: earthly --ci --org expressvpn --satellite wolfssl-rs +fmt
-  lint:
-    runs-on: ubuntu-latest
-    environment: earthly_visit_temp
-    env:
-      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
-      FORCE_COLOR: 1
-    steps:
-      - uses: earthly/actions-setup@v1
-        with:
-          version: v0.7.20
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Run +lint on Earthly satellite
-        run: earthly --ci --org expressvpn --satellite wolfssl-rs +lint
-  check-dependencies:
-    runs-on: ubuntu-latest
-    environment: earthly_visit_temp
-    env:
-      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
-      FORCE_COLOR: 1
-    steps:
-      - uses: earthly/actions-setup@v1
-        with:
-          version: v0.7.20
-      - uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: Run +check-dependencies on Earthly satellite
-        run: earthly --ci --org expressvpn --satellite wolfssl-rs +check-dependencies

--- a/Earthfile
+++ b/Earthfile
@@ -9,7 +9,7 @@ WORKDIR /wolfssl-rs
 build-deps:
     RUN apt-get update -qq
     RUN apt-get install --no-install-recommends -qq autoconf autotools-dev libtool-bin clang cmake bsdmainutils
-    RUN cargo install --locked cargo-deny cargo-llvm-cov
+    DO rust-udc+CARGO --keep_fingerprints=true --args="install --locked cargo-deny cargo-llvm-cov"
     RUN rustup component add clippy
     RUN rustup component add rustfmt
     RUN rustup component add llvm-tools-preview

--- a/Earthfile
+++ b/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.7
-# Importing https://github.com/earthly/lib/tree/2.2.5/rust via commit hash pinning because git tags can be changed
-IMPORT github.com/earthly/lib/rust:7478ffcedbade1997ecdf375099c6a9dc7d3861f AS rust-udc
+# Importing https://github.com/earthly/lib/tree/2.2.6/rust via commit hash pinning because git tags can be changed
+IMPORT github.com/earthly/lib/rust:0b9edb9f116ebf6f9a7426e45593cec457503ed9 AS rust-udc
 
 FROM rust:1.73.0
 

--- a/Earthfile
+++ b/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.7
-# Importing https://github.com/earthly/lib/tree/2.2.4/rust via commit hash pinning because git tags can be changed
-IMPORT github.com/earthly/lib/rust:4cfebf74b5805ad943d325a94601e808afbf6e6f AS rust-udc
+# Importing https://github.com/earthly/lib/tree/2.2.5/rust via commit hash pinning because git tags can be changed
+IMPORT github.com/earthly/lib/rust:7478ffcedbade1997ecdf375099c6a9dc7d3861f AS rust-udc
 
 FROM rust:1.73.0
 
@@ -21,30 +21,30 @@ copy-src:
 # build-dev builds with the Cargo dev profile and produces debug artifacts
 build-dev:
     FROM +copy-src
-    DO rust-udc+CARGO --args="build" --output="debug/[^/]+"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="build" --output="debug/[^/]+"
     SAVE ARTIFACT target/debug /debug AS LOCAL artifacts/debug
 
 # build-release builds with the Cargo release profile and produces release artifacts
 build-release:
     FROM +copy-src
-    DO rust-udc+CARGO --args="build --release" --output="release/[^/]+"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="build --release" --output="release/[^/]+"
     SAVE ARTIFACT target/release /release AS LOCAL artifacts/release
 
 # run-tests executes all unit and integration tests via Cargo
 run-tests:
     FROM +copy-src
-    DO rust-udc+CARGO --args="test"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="test"
 
 # run-coverage generates a report of code coverage by unit and integration tests via cargo-llvm-cov
 run-coverage:
     FROM +copy-src
-    DO rust-udc+CARGO --args="llvm-cov test"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="llvm-cov test"
 
     RUN mkdir /tmp/coverage
 
-    DO rust-udc+CARGO --args="llvm-cov report --summary-only --output-path /tmp/coverage/summary.txt"
-    DO rust-udc+CARGO --args="llvm-cov report --json --output-path /tmp/coverage/coverage.json"
-    DO rust-udc+CARGO --args="llvm-cov report --html --output-dir /tmp/coverage/"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="llvm-cov report --summary-only --output-path /tmp/coverage/summary.txt"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="llvm-cov report --json --output-path /tmp/coverage/coverage.json"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="llvm-cov report --html --output-dir /tmp/coverage/"
     SAVE ARTIFACT /tmp/coverage/*
 
 # build runs tests and then creates a release build
@@ -55,22 +55,22 @@ build:
 # build-crate creates a .crate file for distribution of source code
 build-crate:
     FROM +copy-src
-    DO rust-udc+CARGO --args="package" --output="package/.*\.crate"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="package" --output="package/.*\.crate"
     SAVE ARTIFACT target/package/*.crate /package/ AS LOCAL artifacts/crate/
 
 # lint runs cargo clippy on the source code
 lint:
     FROM +copy-src
-    DO rust-udc+CARGO --args="clippy --all-features --all-targets -- -D warnings"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="clippy --all-features --all-targets -- -D warnings"
     ENV RUSTDOCFLAGS="-D warnings"
-    DO rust-udc+CARGO --args="doc --document-private-items"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="doc --document-private-items"
 
 # fmt checks whether Rust code is formatted according to style guidelines
 fmt:
     FROM +copy-src
-    DO rust-udc+CARGO --args="fmt --check"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="fmt --check"
 
 # check-dependencies lints our dependencies via cargo-deny
 check-dependencies:
     FROM +copy-src
-    DO rust-udc+CARGO --args="deny --all-features check --deny warnings bans license sources"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="deny --all-features check --deny warnings bans license sources"


### PR DESCRIPTION
- Bumping to https://github.com/earthly/lib/compare/2.2.4...2.2.5 allow us to use `--keep_fingerprints=true` since after 45423285950 this workaround is not needed.
- Bumping to https://github.com/earthly/lib/compare/2.2.5...2.2.6 keeps us up to date, but since we do not use `--output` doesn't affect us here.
- Use the UDC to install `cargo-deny` and `cargo-llvm-cov` so we will cache things
- Use a matrix job for the simple "just run Earthly target" cases, less repetition