### PR TITLE
ci: use repo secrets instead of environment secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         target: [run-tests, build-release, fmt, lint, check-dependencies]
     runs-on: ubuntu-latest
-    environment: earthly_visit_temp
     env:
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
       FORCE_COLOR: 1
@@ -33,7 +32,6 @@ jobs:
         run: earthly --ci --org expressvpn --satellite wolfssl-rs +${{ matrix.target }}
   coverage:
     runs-on: ubuntu-latest
-    environment: earthly_visit_temp
     env:
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
       FORCE_COLOR: 1


### PR DESCRIPTION
There was a lot of noise in the PRs due to the environment secret usuage. Everytime we made a change in the PR, the PR is flooded with

`deployed to environment...`

messages.

So we moved the secrets from environment to repo level. This commit removes the environment value from ci so that github actions will use repo secrets.