### PR TITLE
wolfssl: Allow key rotation for DTLS 1.3 connections

### DIFF
--- a/wolfssl/src/lib.rs
+++ b/wolfssl/src/lib.rs
@@ -202,6 +202,11 @@ impl Protocol {
     fn is_tls_13(&self) -> bool {
         matches!(self, Self::TlsClientV1_3 | Self::TlsServerV1_3)
     }
+
+    /// Checks if the protocol is compatible with DTLS 1.3
+    fn is_dtls_13(&self) -> bool {
+        matches!(self, Self::DtlsClientV1_3 | Self::DtlsServerV1_3)
+    }
 }
 
 /// Defines a CA certificate

--- a/wolfssl/src/lib.rs
+++ b/wolfssl/src/lib.rs
@@ -198,7 +198,7 @@ impl Protocol {
         NonNull::new(ptr)
     }
 
-    /// Checks if the method is compatible with TLS 1.3
+    /// Checks if the protocol is compatible with TLS 1.3
     fn is_tls_13(&self) -> bool {
         matches!(self, Self::TlsClientV1_3 | Self::TlsServerV1_3)
     }


### PR DESCRIPTION
Although the [documentation] talks about "TLS 1.3" this feature is available for DTLS 1.3 too (confirmed in the code).

[documentation]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__IO.html#function-wolfssl_update_keys