### PR TITLE
Update Earthly to v0.7.21 and UDC to v2.2.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: earthly/actions-setup@v1
         with:
-          version: v0.7.20
+          version: v0.7.21
       - uses: actions/checkout@v3
         with:
           submodules: true
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: earthly/actions-setup@v1
         with:
-          version: v0.7.20
+          version: v0.7.21
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/Earthfile
+++ b/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.7
-# Importing https://github.com/earthly/lib/tree/2.2.6/rust via commit hash pinning because git tags can be changed
-IMPORT github.com/earthly/lib/rust:0b9edb9f116ebf6f9a7426e45593cec457503ed9 AS rust-udc
+# Importing https://github.com/earthly/lib/tree/2.2.7/rust via commit hash pinning because git tags can be changed
+IMPORT github.com/earthly/lib/rust:72ce5042ba283ced1bcafe2c69d0886c5a549e71 AS rust-udc
 
 FROM rust:1.73.0
 


### PR DESCRIPTION
Before merging:
- [x] Wait for Earthly satellite v0.7.21 release (due 2023-10-26)
- [x] `earthly satellite --org expressvpn update wolfssl-rs` (may need `sleep` first to allow the update to occur)
- [x] Rerun CI to ensure it still works