### PR TITLE
Add some predicate helpers to `ContextBuilder` and `SessionConfig`

### DIFF
--- a/wolfssl/src/ssl.rs
+++ b/wolfssl/src/ssl.rs
@@ -77,6 +77,30 @@ impl<IOCB: IOCallbacks> SessionConfig<IOCB> {
         }
     }
 
+    /// When `cond` is True call `func` on `Self`
+    pub fn when<F>(self, cond: bool, func: F) -> Self
+    where
+        F: FnOnce(Self) -> Self,
+    {
+        if cond {
+            func(self)
+        } else {
+            self
+        }
+    }
+
+    /// When `maybe` is Some(_) call `func` on `Self` and the contained value
+    pub fn when_some<F, T>(self, maybe: Option<T>, func: F) -> Self
+    where
+        F: FnOnce(Self, T) -> Self,
+    {
+        if let Some(t) = maybe {
+            func(self, t)
+        } else {
+            self
+        }
+    }
+
     /// Sets [`Self::dtls_use_nonblock`]
     pub fn with_dtls_nonblocking(mut self, is_nonblocking: bool) -> Self {
         self.dtls_use_nonblock = Some(is_nonblocking);


### PR DESCRIPTION
This simplifies:
```rust
let wolfssl = wolfssl::ContextBuilder::new(protocol)?
    .with_root_certificate(root_ca)?
    .with_cipher_list(Cipher::default().as_cipher_list(connection_type))?;

let wolfssl = if connection_type.is_datagram() {
    wolfssl.with_secure_renegotiation()?
} else {
    wolfssl
};
```
into
```rust
let wolfssl = wolfssl::ContextBuilder::new(protocol)?
    .with_root_certificate(root_ca)?
    .with_cipher_list(Cipher::default().as_cipher_list(connection_type))?
    .try_when(connection_type.is_datagram(), |s| s.with_dtls_nonblocking(true))?;
```

or

```rust
let wolfssl = wolfssl::ContextBuilder::new(protocol)?
    .with_private_key(server_key)?
    .with_certificate(server_cert)?
    .with_groups(SERVER_CURVE_BASE_GROUPS)?;

let wolfssl = if connection_type.is_datagram() {
    wolfssl.with_secure_renegotiation()?.with_cipher_list(
	"TLS13-CHACHA20-POLY1305-SHA256:ECDHE-RSA-CHACHA20-POLY1305:TLS13-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384",
    )?
} else {
    wolfssl.with_cipher_list("TLS13-AES256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256")?
};
```
into
```rust
let wolfssl = wolfssl::ContextBuilder::new(protocol)?
    .with_private_key(server_key)?
    .with_certificate(server_cert)?
    .with_groups(SERVER_CURVE_BASE_GROUPS)?
    .try_when(connection_type.is_datagram(),|s| s.with_secure_renegotiation())?
    .try_when(connection_type.is_datagram(),|s| s.with_cipher_list("TLS13-CHACHA20-POLY1305-SHA256:ECDHE-RSA-CHACHA20-POLY1305:TLS13-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"))?
    .try_when(connection_type.is_stream(),|s| s.with_cipher_list("TLS13-AES256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256"))?;
```