### PR TITLE
LIT-193: New trait for receiving TLS1.3 secrets in debug mode

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -64,7 +64,7 @@ lint:
     FROM +copy-src
     DO rust-udc+CARGO --keep_fingerprints=true --args="clippy --all-features --all-targets -- -D warnings"
     ENV RUSTDOCFLAGS="-D warnings"
-    DO rust-udc+CARGO --keep_fingerprints=true --args="doc --document-private-items"
+    DO rust-udc+CARGO --keep_fingerprints=true --args="doc --all-features --document-private-items"
 
 # fmt checks whether Rust code is formatted according to style guidelines
 fmt:

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -42,7 +42,7 @@ fn copy_wolfssl(dest: &str) -> std::io::Result<()> {
 }
 
 const PATCH_DIR: &str = "patches";
-const PATCHES: &[&str] = &[ ];
+const PATCHES: &[&str] = &[];
 
 /**
  * Apply patch to wolfssl-src
@@ -119,6 +119,7 @@ fn build_wolfssl(dest: &str) -> PathBuf {
 
     if cfg!(feature = "debug") {
         conf.enable("debug", None);
+        conf.cflag("-DHAVE_SECRET_CALLBACK");
     }
 
     if cfg!(feature = "postquantum") {

--- a/wolfssl/src/debug.rs
+++ b/wolfssl/src/debug.rs
@@ -1,0 +1,105 @@
+#![cfg(feature = "debug")]
+
+use std::os::raw::{c_int, c_uint};
+use std::sync::Arc;
+
+/// Application provided callbacks to receive TLS1.3 secrets
+///
+/// There are two apis in this trait.
+/// Application can opt to receive either raw secrets or String which is suitable to use in
+/// WireShark keylog
+/// <https://www.wireshark.org/docs/wsug_html_chunked/ChIOExportSection.html#ChIOExportTLSSessionKeys>
+/// <https://wiki.wireshark.org/TLS#using-the-pre-master-secret>
+pub trait Tls13SecretCallbacks {
+    /// Called when WolfSSL wishes to send new TLS1.3 secret used
+    /// `secret` is formatted as WireShark keylog string.
+    /// It can be saved to a file and used in WireShark directly
+    fn wireshark_keylog(&self, _secret: String);
+
+    /// Called when WolfSSL wishes to send new TLS1.3 secret used
+    /// Random value and secrets along with secret type is send separately
+    /// The default implementation parses the secret/random and generate the
+    /// WireShark compatible keylog string and call `Tls13SecretCallbacks::wireshark_keylog`.
+    ///
+    /// Application can choose to override this to get the secret/random directly.
+    fn secrets(&self, secret_type: Tls13Secret, random: &[u8], secret: &[u8]) {
+        let mut keylog = secret_type.to_string();
+        keylog.push(' ');
+
+        random
+            .iter()
+            .for_each(|i| keylog.push_str(&format!("{:02x}", i)));
+        keylog.push(' ');
+
+        secret
+            .iter()
+            .for_each(|f| keylog.push_str(&format!("{:02x}", f)));
+        keylog.push('\n');
+
+        self.wireshark_keylog(keylog);
+    }
+}
+
+/// Convenience type to use as function arguments
+pub type Tls13SecretCallbacksArg = Arc<dyn Tls13SecretCallbacks + Send + Sync>;
+
+pub(crate) const RANDOM_SIZE: usize = 32;
+
+/// Tls13 Secret types
+/// To be used in Wireshark
+pub enum Tls13Secret {
+    /// "CLIENT_EARLY_TRAFFIC_SECRET"
+    ClientEarlyTrafficSecret,
+    /// "CLIENT_HANDSHAKE_TRAFFIC_SECRET"
+    ClientHandshakeTrafficSecret,
+    /// "SERVER_HANDSHAKE_TRAFFIC_SECRET"
+    ServerHandshakeTrafficSecret,
+    /// "CLIENT_TRAFFIC_SECRET_0"
+    ClientTrafficSecret,
+    ///"SERVER_TRAFFIC_SECRET_0"
+    ServerTrafficSecret,
+    /// "EARLY_EXPORTER_SECRET"
+    EarlyExporterSecret,
+    ///
+    ExporterSecret,
+    /// "EXPORTER_SECRET"
+    UnknownSecret(c_uint),
+}
+
+impl ToString for Tls13Secret {
+    fn to_string(&self) -> String {
+        use Tls13Secret::*;
+        match self {
+            ClientEarlyTrafficSecret => "CLIENT_EARLY_TRAFFIC_SECRET",
+            ClientHandshakeTrafficSecret => "CLIENT_HANDSHAKE_TRAFFIC_SECRET",
+            ServerHandshakeTrafficSecret => "SERVER_HANDSHAKE_TRAFFIC_SECRET",
+            ClientTrafficSecret => "CLIENT_TRAFFIC_SECRET_0",
+            ServerTrafficSecret => "SERVER_TRAFFIC_SECRET_0",
+            EarlyExporterSecret => "EARLY_EXPORTER_SECRET",
+            ExporterSecret => "EXPORTER_SECRET",
+            UnknownSecret(_e) => "UNKNOWN_SECRET",
+        }
+        .to_string()
+    }
+}
+
+impl From<c_int> for Tls13Secret {
+    fn from(value: c_int) -> Self {
+        match value as c_uint {
+            wolfssl_sys::Tls13Secret_CLIENT_EARLY_TRAFFIC_SECRET => {
+                Tls13Secret::ClientEarlyTrafficSecret
+            }
+            wolfssl_sys::Tls13Secret_CLIENT_HANDSHAKE_TRAFFIC_SECRET => {
+                Tls13Secret::ClientHandshakeTrafficSecret
+            }
+            wolfssl_sys::Tls13Secret_SERVER_HANDSHAKE_TRAFFIC_SECRET => {
+                Tls13Secret::ServerHandshakeTrafficSecret
+            }
+            wolfssl_sys::Tls13Secret_CLIENT_TRAFFIC_SECRET => Tls13Secret::ClientTrafficSecret,
+            wolfssl_sys::Tls13Secret_SERVER_TRAFFIC_SECRET => Tls13Secret::ServerTrafficSecret,
+            wolfssl_sys::Tls13Secret_EARLY_EXPORTER_SECRET => Tls13Secret::EarlyExporterSecret,
+            wolfssl_sys::Tls13Secret_EXPORTER_SECRET => Tls13Secret::ExporterSecret,
+            e => Tls13Secret::UnknownSecret(e),
+        }
+    }
+}

--- a/wolfssl/src/lib.rs
+++ b/wolfssl/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod callback;
 mod context;
+mod debug;
 mod error;
 mod rng;
 mod ssl;
@@ -16,6 +17,9 @@ pub use rng::*;
 pub use ssl::*;
 
 pub use error::{Error, Poll, Result};
+
+#[cfg(feature = "debug")]
+pub use debug::*;
 
 use std::ptr::NonNull;
 

--- a/wolfssl/src/ssl.rs
+++ b/wolfssl/src/ssl.rs
@@ -15,6 +15,12 @@ use std::{
     time::Duration,
 };
 
+#[cfg(feature = "debug")]
+use {
+    crate::debug::{Tls13SecretCallbacksArg, RANDOM_SIZE},
+    std::sync::Arc,
+};
+
 /// Convert a [`std::io::ErrorKind`] into WOLFSSL_CBIO error as descibed in [`EmbedReceive`][0].
 ///
 /// `would_block` is returned if the variant is
@@ -61,6 +67,9 @@ pub struct SessionConfig<IOCB: IOCallbacks> {
     pub checked_domain_name: Option<String>,
     /// If set, specifies a curve group to use for key share
     pub keyshare_group: Option<CurveGroup>,
+    /// If set, callback will be called for all TLS1.3 secret
+    #[cfg(feature = "debug")]
+    pub keylogger: Option<Tls13SecretCallbacksArg>,
 }
 
 impl<IOCB: IOCallbacks> SessionConfig<IOCB> {
@@ -74,6 +83,8 @@ impl<IOCB: IOCallbacks> SessionConfig<IOCB> {
             server_name_indicator: Default::default(),
             checked_domain_name: Default::default(),
             keyshare_group: Default::default(),
+            #[cfg(feature = "debug")]
+            keylogger: Default::default(),
         }
     }
 
@@ -130,6 +141,13 @@ impl<IOCB: IOCallbacks> SessionConfig<IOCB> {
         self.keyshare_group = Some(curve);
         self
     }
+
+    /// Sets [`Self::keylogger`]
+    #[cfg(feature = "debug")]
+    pub fn with_key_logger(mut self, keylogger: Tls13SecretCallbacksArg) -> Self {
+        self.keylogger = Some(keylogger);
+        self
+    }
 }
 
 // Wrap a valid pointer to a [`wolfssl_sys::WOLFSSL`] such that we can
@@ -167,6 +185,9 @@ pub struct Session<IOCB: IOCallbacks> {
 
     /// Box so we have a stable address to pass to FFI.
     io: Box<IOCB>,
+
+    #[cfg(feature = "debug")]
+    secret_cb: Option<Tls13SecretCallbacksArg>,
 }
 
 /// Error creating a [`Session`] object.
@@ -201,6 +222,8 @@ impl<IOCB: IOCallbacks> Session<IOCB> {
                 NonNull::new(ptr).ok_or(NewSessionError::CreateFailed)?,
             )),
             io: Box::new(config.io),
+            #[cfg(feature = "debug")]
+            secret_cb: Default::default(),
         };
 
         session.register_io_context();
@@ -229,6 +252,13 @@ impl<IOCB: IOCallbacks> Session<IOCB> {
             session
                 .use_key_share_curve(curve)
                 .map_err(|e| NewSessionError::SetupFailed("use_key_share_curve", e))?;
+        }
+
+        #[cfg(feature = "debug")]
+        if let Some(keylogger) = config.keylogger {
+            session
+                .enable_tls13_keylog(keylogger)
+                .map_err(|e| NewSessionError::SetupFailed("keylogger", e))?;
         }
 
         Ok(session)
@@ -1099,6 +1129,73 @@ impl<IOCB: IOCallbacks> Session<IOCB> {
             e @ wolfssl_sys::BAD_FUNC_ARG => unreachable!("{e:?}"),
             e => unreachable!("{e:?}"),
         }
+    }
+
+    /// Enable TLS1.3 key logging for applications
+    #[cfg(feature = "debug")]
+    pub(crate) fn enable_tls13_keylog(&mut self, secret_cb: Tls13SecretCallbacksArg) -> Result<()> {
+        self.secret_cb = Some(secret_cb.clone());
+
+        // let keylog_c = Box::into_raw(Box::new(keylog));
+
+        // SAFETY: No documentation available for [`wolfSSL_KeepArrays`] [`wolfSSL_set_tls13_secret_cb`].
+        // But based on api implementation, it expects a valid pointer to `WOLFSSL`.
+        //
+        // This implementation is taken from following examples:
+        // https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/client-tls13.c
+        // https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/server-tls13.c
+        //
+        // `secret_cb` is an Arc pointer and we save one strong reference inside `Session`
+        // This prevents the memory being freed when `secret_cb` goes out of scope.
+        // So it is safe to send this pointer as callback context and `secret_cb` will be valid
+        // as long the connection is valid
+        match unsafe {
+            let ssl = self.ssl.lock().as_ptr();
+            wolfssl_sys::wolfSSL_KeepArrays(ssl);
+            wolfssl_sys::wolfSSL_set_tls13_secret_cb(
+                ssl,
+                Some(Self::tls13_secret_cb),
+                Arc::as_ptr(&secret_cb) as *mut c_void,
+            )
+        } {
+            wolfssl_sys::WOLFSSL_SUCCESS => Ok(()),
+            wolfssl_sys::WOLFSSL_FATAL_ERROR => panic!("No SSL context"),
+            e => unreachable!("{e:?}"),
+        }
+    }
+
+    #[cfg(feature = "debug")]
+    unsafe extern "C" fn tls13_secret_cb(
+        ssl: *mut wolfssl_sys::WOLFSSL,
+        id: ::std::os::raw::c_int,
+        secret: *const ::std::os::raw::c_uchar,
+        secret_size: ::std::os::raw::c_int,
+        ctx: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int {
+        debug_assert!(!ssl.is_null());
+        debug_assert!(!secret.is_null());
+        debug_assert!(!ctx.is_null());
+
+        // let keylog = Box::from_raw(ctx as *mut Arc<dyn Tls13SecretCallbacks>);
+        let secret_cb = &*(ctx as *mut Tls13SecretCallbacksArg);
+
+        let mut random: Vec<u8> = vec![0; RANDOM_SIZE];
+        let get_random = if 1 == wolfssl_sys::wolfSSL_is_server(ssl) {
+            wolfssl_sys::wolfSSL_get_server_random
+        } else {
+            wolfssl_sys::wolfSSL_get_client_random
+        };
+        let random_size = get_random(ssl, random.as_mut_ptr() as *mut c_uchar, random.len());
+        if random_size == 0 {
+            return 0;
+        }
+        let random: &[u8] = &random[..random_size];
+
+        let secret = std::slice::from_raw_parts(secret as *mut u8, secret_size as usize);
+
+        secret_cb.secrets(id.into(), random, secret);
+
+        0
     }
 }
 

--- a/wolfssl/src/ssl.rs
+++ b/wolfssl/src/ssl.rs
@@ -16,10 +16,7 @@ use std::{
 };
 
 #[cfg(feature = "debug")]
-use {
-    crate::debug::{Tls13SecretCallbacksArg, RANDOM_SIZE},
-    std::sync::Arc,
-};
+use crate::debug::{Tls13SecretCallbacksArg, RANDOM_SIZE};
 
 /// Convert a [`std::io::ErrorKind`] into WOLFSSL_CBIO error as descibed in [`EmbedReceive`][0].
 ///
@@ -1136,7 +1133,11 @@ impl<IOCB: IOCallbacks> Session<IOCB> {
     pub(crate) fn enable_tls13_keylog(&mut self, secret_cb: Tls13SecretCallbacksArg) -> Result<()> {
         self.secret_cb = Some(secret_cb.clone());
 
-        // let keylog_c = Box::into_raw(Box::new(keylog));
+        // SAFETY: `secret_cb` is an Arc pointer and we save one strong reference inside `Session`
+        // This prevents the memory being freed when `secret_cb` goes out of scope.
+        // So it is safe to send this pointer as callback context and `secret_cb` will be valid
+        // as long the connection is valid
+        let secret_cb = Box::into_raw(Box::new(secret_cb)) as *mut c_void;
 
         // SAFETY: No documentation available for [`wolfSSL_KeepArrays`] [`wolfSSL_set_tls13_secret_cb`].
         // But based on api implementation, it expects a valid pointer to `WOLFSSL`.
@@ -1144,19 +1145,10 @@ impl<IOCB: IOCallbacks> Session<IOCB> {
         // This implementation is taken from following examples:
         // https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/client-tls13.c
         // https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/server-tls13.c
-        //
-        // `secret_cb` is an Arc pointer and we save one strong reference inside `Session`
-        // This prevents the memory being freed when `secret_cb` goes out of scope.
-        // So it is safe to send this pointer as callback context and `secret_cb` will be valid
-        // as long the connection is valid
         match unsafe {
             let ssl = self.ssl.lock().as_ptr();
             wolfssl_sys::wolfSSL_KeepArrays(ssl);
-            wolfssl_sys::wolfSSL_set_tls13_secret_cb(
-                ssl,
-                Some(Self::tls13_secret_cb),
-                Arc::as_ptr(&secret_cb) as *mut c_void,
-            )
+            wolfssl_sys::wolfSSL_set_tls13_secret_cb(ssl, Some(Self::tls13_secret_cb), secret_cb)
         } {
             wolfssl_sys::WOLFSSL_SUCCESS => Ok(()),
             wolfssl_sys::WOLFSSL_FATAL_ERROR => panic!("No SSL context"),
@@ -1176,8 +1168,9 @@ impl<IOCB: IOCallbacks> Session<IOCB> {
         debug_assert!(!secret.is_null());
         debug_assert!(!ctx.is_null());
 
-        // let keylog = Box::from_raw(ctx as *mut Arc<dyn Tls13SecretCallbacks>);
-        let secret_cb = &*(ctx as *mut Tls13SecretCallbacksArg);
+        // SAFETY: We have only one strong reference in `self.secret_cb`
+        // Leak the Box pointer, so that it will not be freed while this function return
+        let secret_cb = Box::leak(Box::from_raw(ctx as *mut Tls13SecretCallbacksArg));
 
         let mut random: Vec<u8> = vec![0; RANDOM_SIZE];
         let get_random = if 1 == wolfssl_sys::wolfSSL_is_server(ssl) {


### PR DESCRIPTION
WolfSSL provides  a way to dump secrets in TLS13 which can be used to decrypt traffic using Wireshark.

Ref: 
https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/server-tls13.c 
https://github.com/wolfSSL/wolfssl-examples/blob/master/tls/client-tls13.c 


This PR adds helpers in wolfssl-rs to support that feature