### PR TITLE
wolfssl: add patch for AES-ARM64 asm bug

### DIFF
--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -47,6 +47,7 @@ const PATCHES: &[&str] = &[
     "0002-SP-ARM64-asm-fix-Montgomery-reduction-by-4.patch",
     "0003-SP-ARM64-P-256-mark-functions-as-SP_NOINLINE.patch",
     "0004-AES-GCM-ARM64-Replace-hardware-crypto-assembly-with-.patch",
+    "0005-AES-GCM-ARM64-Fix-clobber-lists.patch",
 ];
 
 /**

--- a/wolfssl-sys/patches/0005-AES-GCM-ARM64-Fix-clobber-lists.patch
+++ b/wolfssl-sys/patches/0005-AES-GCM-ARM64-Fix-clobber-lists.patch
@@ -1,0 +1,71 @@
+From 14ba944f6c32f3cfc875d39d40b3aed2c2962391 Mon Sep 17 00:00:00 2001
+From: res0nance <raihaanhimself@gmail.com>
+Date: Thu, 30 Nov 2023 12:33:42 +0800
+Subject: [PATCH] AES GCM ARM64: Fix clobber lists
+
+---
+ wolfcrypt/src/port/arm/armv8-aes.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/wolfcrypt/src/port/arm/armv8-aes.c b/wolfcrypt/src/port/arm/armv8-aes.c
+index 42252f21de5..455d30bba37 100644
+--- a/wolfcrypt/src/port/arm/armv8-aes.c
++++ b/wolfcrypt/src/port/arm/armv8-aes.c
+@@ -3508,7 +3508,7 @@ static int Aes128GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+           [aSz] "+r" (authInSz), [sz] "+r" (sz), [aad] "+r" (authIn)
+         : [ctr] "r" (ctr), [scratch] "r" (scratch),
+           [h] "m" (aes->gcm.H), [tag] "r" (authTag), [tagSz] "r" (authTagSz)
+-        : "cc", "w11", "w12", "w13", "w14", "w15", "w16",
++        : "cc", "memory", "x11", "x12", "w13", "x14", "x15", "w16",
+           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
+           "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
+           "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
+@@ -5271,7 +5271,7 @@ static int Aes192GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+           [aSz] "+r" (authInSz), [sz] "+r" (sz), [aad] "+r" (authIn)
+         : [ctr] "r" (ctr), [scratch] "r" (scratch),
+           [h] "m" (aes->gcm.H), [tag] "r" (authTag), [tagSz] "r" (authTagSz)
+-        : "cc", "w11", "w12", "w13", "w14", "w15", "w16",
++        : "cc", "memory", "x11", "x12", "w13", "x14", "x15", "w16",
+           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
+           "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
+           "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
+@@ -7165,7 +7165,7 @@ static int Aes256GcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+           [aSz] "+r" (authInSz), [sz] "+r" (sz), [aad] "+r" (authIn)
+         : [ctr] "r" (ctr), [scratch] "r" (scratch),
+           [h] "m" (aes->gcm.H), [tag] "r" (authTag), [tagSz] "r" (authTagSz)
+-        : "cc", "w11", "w12", "w13", "w14", "w15", "w16",
++        : "cc", "memory", "x11", "x12", "w13", "x14", "x15", "w16",
+           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
+           "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
+           "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
+@@ -8878,7 +8878,7 @@ static int Aes128GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+           [ret] "+r" (ret)
+         : [ctr] "r" (ctr), [scratch] "r" (scratch),
+           [h] "m" (aes->gcm.H), [tag] "r" (authTag), [tagSz] "r" (authTagSz)
+-        : "cc", "memory", "w11", "w12", "w13", "w14", "w15", "w16",
++        : "cc", "memory", "x11", "x12", "w13", "x14", "x15", "w16",
+           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
+           "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
+           "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
+@@ -10646,7 +10646,7 @@ static int Aes192GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+           [ret] "+r" (ret)
+         : [ctr] "r" (ctr), [scratch] "r" (scratch),
+           [h] "m" (aes->gcm.H), [tag] "r" (authTag), [tagSz] "r" (authTagSz)
+-        : "cc", "memory", "w11", "w12", "w13", "w14", "w15", "w16",
++        : "cc", "memory", "x11", "x12", "w13", "x14", "x15", "w16",
+           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
+           "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
+           "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
+@@ -12535,7 +12535,7 @@ static int Aes256GcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
+           [ret] "+r" (ret)
+         : [ctr] "r" (ctr), [scratch] "r" (scratch),
+           [h] "m" (aes->gcm.H), [tag] "r" (authTag), [tagSz] "r" (authTagSz)
+-        : "cc", "memory", "w11", "w12", "w13", "w14", "w15", "w16",
++        : "cc", "memory", "x11", "x12", "w13", "x14", "x15", "w16",
+           "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
+           "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
+           "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",
+
+-- 
+2.43.0
+


### PR DESCRIPTION
This patch is pulled from lightway-core:
https://github.com/expressvpn/lightway-core/commit/6742c6503691b1d628f9b94a10a7929b91658498

Related PR:
https://github.com/expressvpn/lightway-core/pull/150