### PR TITLE
GHA: add changelog while updating rust version

### DIFF
--- a/.github/workflows/nightly-rust-update-check.yaml
+++ b/.github/workflows/nightly-rust-update-check.yaml
@@ -42,3 +42,4 @@ jobs:
         commit-message: "[auto] Update Rust toolchain to ${{ steps.check-version.outputs.rust }}"
         branch: gha/rust-toolchain-update
         title: "[auto] Update Rust toolchain to ${{ steps.check-version.outputs.rust }}"
+        body: "Changelog: https://releases.rs/docs/${{ steps.check-version.outputs.rust }}/"


### PR DESCRIPTION
Add link to changelog in PR body.

Official rust changelog is a single page with URL having release date too. https://doc.rust-lang.org/nightly/releases.html#version-1750-2023-12-28

Easier to use `releases.rs` to point to specific version changelog, since it does not have release date in URLs.