### PR TITLE
wolfssl-sys: rebuild if c source changed & fixup path conventions in build.rs

### DIFF
--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -31,6 +31,7 @@ impl bindgen::callbacks::ParseCallbacks for IgnoreMacros {
  * Copy WolfSSL
  */
 fn copy_wolfssl(dest: &str) -> std::io::Result<()> {
+    println!("cargo:rerun-if-changed=wolfssl-src");
     Command::new("cp")
         .arg("-rf")
         .arg("wolfssl-src")

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -234,8 +234,8 @@ fn main() -> std::io::Result<()> {
     }
 
     println!(
-        "cargo:rustc-link-search=native={}/lib/",
-        out_dir.to_str().unwrap()
+        "cargo:rustc-link-search=native={}",
+        wolfssl_install_dir.join("lib").to_str().unwrap()
     );
 
     println!("cargo:include={}", out_dir.to_str().unwrap());

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -48,8 +48,8 @@ const PATCHES: &[&str] = &[];
 /**
  * Apply patch to wolfssl-src
  */
-fn apply_patch(wolfssl_path: &Path, patch: &str) {
-    let patch = format!("{}/{}", PATCH_DIR, patch);
+fn apply_patch(wolfssl_path: &Path, patch: impl AsRef<Path>) {
+    let patch = Path::new(PATCH_DIR).join(patch);
 
     let patch_buffer = File::open(patch).unwrap();
     Command::new("patch")
@@ -129,9 +129,15 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
     if cfg!(feature = "postquantum") {
         // Post Quantum support is provided by liboqs
         if let Some(include) = std::env::var_os("DEP_OQS_ROOT") {
-            let oqs_path = &include.into_string().unwrap();
-            conf.cflag(format!("-I{oqs_path}/build/include/"));
-            conf.ldflag(format!("-L{oqs_path}/build/lib/"));
+            let oqs_path = Path::new(&include);
+            conf.cflag(format!(
+                "-I{}",
+                oqs_path.join("build/include/").to_str().unwrap()
+            ));
+            conf.ldflag(format!(
+                "-L{}",
+                oqs_path.join("build/lib/").to_str().unwrap()
+            ));
             conf.with("liboqs", None);
         } else {
             panic!("Post Quantum requested but liboqs appears to be missing?");

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -202,20 +202,15 @@ fn main() -> std::io::Result<()> {
         .parse_callbacks(Box::new(ignored_macros))
         .formatter(bindgen::Formatter::Rustfmt);
 
-    let builder = builder
-        .allowlist_file(wolfssl_include_dir.join("wolfssl/.*.h").to_str().unwrap())
-        .allowlist_file(
-            wolfssl_include_dir
-                .join("wolfssl/wolfcrypt/.*.h")
-                .to_str()
-                .unwrap(),
-        )
-        .allowlist_file(
-            wolfssl_include_dir
-                .join("wolfssl/openssl/compat_types.h")
-                .to_str()
-                .unwrap(),
-        );
+    let builder = [
+        "wolfssl/.*.h",
+        "wolfssl/wolfcrypt/.*.h",
+        "wolfssl/openssl/compat_types.h",
+    ]
+    .iter()
+    .fold(builder, |b, p| {
+        b.allowlist_file(wolfssl_include_dir.join(p).to_str().unwrap())
+    });
 
     let builder = builder.blocklist_function("wolfSSL_BIO_vprintf");
 

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -238,8 +238,6 @@ fn main() -> std::io::Result<()> {
         wolfssl_install_dir.join("lib").to_str().unwrap()
     );
 
-    println!("cargo:include={}", out_dir.to_str().unwrap());
-
     // Invalidate the built crate whenever the wrapper changes
     println!("cargo:rerun-if-changed=wrapper.h");
 

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -30,7 +30,7 @@ impl bindgen::callbacks::ParseCallbacks for IgnoreMacros {
 /**
  * Copy WolfSSL
  */
-fn copy_wolfssl(dest: &str) -> std::io::Result<PathBuf> {
+fn copy_wolfssl(dest: &Path) -> std::io::Result<PathBuf> {
     println!("cargo:rerun-if-changed=wolfssl-src");
     Command::new("cp")
         .arg("-rf")
@@ -39,7 +39,7 @@ fn copy_wolfssl(dest: &str) -> std::io::Result<PathBuf> {
         .status()
         .unwrap();
 
-    Ok(Path::new(dest).join("wolfssl-src"))
+    Ok(dest.join("wolfssl-src"))
 }
 
 const PATCH_DIR: &str = "patches";
@@ -161,7 +161,7 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
 
 fn main() -> std::io::Result<()> {
     // Get the build directory
-    let out_dir = env::var("OUT_DIR").unwrap();
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     // Extract WolfSSL
     let wolfssl_src = copy_wolfssl(&out_dir)?;
@@ -233,9 +233,12 @@ fn main() -> std::io::Result<()> {
         println!("cargo:rustc-link-lib=static=oqs");
     }
 
-    println!("cargo:rustc-link-search=native={}/lib/", out_dir);
+    println!(
+        "cargo:rustc-link-search=native={}/lib/",
+        out_dir.to_str().unwrap()
+    );
 
-    println!("cargo:include={}", out_dir);
+    println!("cargo:include={}", out_dir.to_str().unwrap());
 
     // Invalidate the built crate whenever the wrapper changes
     println!("cargo:rerun-if-changed=wrapper.h");

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -223,7 +223,7 @@ fn main() -> std::io::Result<()> {
 
     // Write out the bindings
     bindings
-        .write_to_file(wolfssl_install_dir.join("bindings.rs"))
+        .write_to_file(out_dir.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 
     // Tell cargo to tell rustc to link in WolfSSL

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -193,21 +193,29 @@ fn main() -> std::io::Result<()> {
     }
 
     let ignored_macros = IgnoreMacros(hash_ignored_macros);
-    let wolfssl_include_dir = format!("{out_dir}/include");
+    let wolfssl_include_dir = wolfssl_install_dir.join("include");
 
     // Build the Rust binding
     let builder = bindgen::Builder::default()
         .header("wrapper.h")
-        .clang_arg(format!("-I{wolfssl_include_dir}/"))
+        .clang_arg(format!("-I{}/", wolfssl_include_dir.to_str().unwrap()))
         .parse_callbacks(Box::new(ignored_macros))
         .formatter(bindgen::Formatter::Rustfmt);
 
     let builder = builder
-        .allowlist_file(format!("{wolfssl_include_dir}/wolfssl/.*.h"))
-        .allowlist_file(format!("{wolfssl_include_dir}/wolfssl/wolfcrypt/.*.h"))
-        .allowlist_file(format!(
-            "{wolfssl_include_dir}/wolfssl/openssl/compat_types.h"
-        ));
+        .allowlist_file(wolfssl_include_dir.join("wolfssl/.*.h").to_str().unwrap())
+        .allowlist_file(
+            wolfssl_include_dir
+                .join("wolfssl/wolfcrypt/.*.h")
+                .to_str()
+                .unwrap(),
+        )
+        .allowlist_file(
+            wolfssl_include_dir
+                .join("wolfssl/openssl/compat_types.h")
+                .to_str()
+                .unwrap(),
+        );
 
     let builder = builder.blocklist_function("wolfSSL_BIO_vprintf");
 


### PR DESCRIPTION
I initially just wanted to add the missing `cargo:rerun-if-changed` since it has been bugging me during debugging sessions where I was modifying wolfssl C code.

But then I realized that the variable naming for the paths was a bit confusing and that had led to us using paths which were "logically" "wrong" -- things worked since the `$OUT_DIR` and where we install the C wolfssl bits happened to overlap but it meant we were rather inconsistent in how we referred to various paths.

Converting all path stuff to use `std::path` means we can use the helpers (`join` etc) and improved portability, but also I suspect that some of the reason we were using the "wrong" path for things semantically was due to it being more convenient to use a handy `&str` which happened to point to the right place than the more correct `Path`/`PathBuf` due to string formatting requirements etc.

