### PR TITLE
cargo: update shlex vulnerable dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,9 +523,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
Fixing error:
```
error[vulnerability]: Multiple issues involving quote API
   ┌─ /work/expressvpn/wolfssl-rs/Cargo.lock:59:1
   │
59 │ shlex 1.2.0 registry+https://github.com/rust-lang/crates.io-index
   │ ----------------------------------------------------------------- security vulnerability detected
   │
   = ID: RUSTSEC-2024-0006
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0006
   = ## Issue 1: Failure to quote characters
```

Found in nightly cargo deny job:
https://github.com/expressvpn/wolfssl-rs/actions/runs/7611230071