### PR TITLE
ci: run weekly cargo update on monday

### DIFF
--- a/.github/workflows/weekly-cargo-update.yaml
+++ b/.github/workflows/weekly-cargo-update.yaml
@@ -1,7 +1,7 @@
 name: Weekly `cargo update`
 on:
   schedule:
-    - cron:  '18 5 * * 3' # 5:18 AM UTC on Wednesdays
+    - cron:  '18 5 * * 1' # 5:18 AM UTC on Mondays
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
instead of Wednesday.
This makes it easier to find issues earlier in week if any.