### PR TITLE
Update to Earthly 0.8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: earthly/actions-setup@v1
         with:
-          version: v0.7.21
+          version: v0.8.3
       - uses: actions/checkout@v3
         with:
           submodules: true
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: earthly/actions-setup@v1
         with:
-          version: v0.7.21
+          version: v0.8.3
       - uses: actions/checkout@v3
         with:
           submodules: true

--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-VERSION --global-cache 0.7
+VERSION 0.8
 # Importing https://github.com/earthly/lib/tree/2.2.11/rust via commit hash pinning because git tags can be changed
 IMPORT github.com/earthly/lib/rust:d5937f9cba1662e7bb07e4c3d69d95db32288a84 AS lib-rust
 


### PR DESCRIPTION
`--global-cache` is the default in this version.
