### PR TITLE
CVPN-525 Fix C Char Type Mismatch Error on linux/arm64

### DIFF
--- a/wolfssl/src/error.rs
+++ b/wolfssl/src/error.rs
@@ -109,7 +109,7 @@ fn wolf_error_string(raw_err: std::ffi::c_ulong) -> String {
             raw_err,
             // note that we are asked for a `char *`, but the
             // following `from_utf8` asks for a Vec<u8>
-            buffer.as_mut_slice().as_mut_ptr() as *mut i8,
+            buffer.as_mut_slice().as_mut_ptr() as *mut std::os::raw::c_char,
         );
     }
     String::from_utf8_lossy(&buffer)


### PR DESCRIPTION
On linux/arm64 when building binaries, there is an error saying the arguments to the function `wolfssl_sys::wolfSSL_ERR_error_string` are incorrect. Further notes by the compiler:
> expected raw pointer `*mut u8`
>    found raw pointer `*mut i8`

Since the code in error was generated by rust-bindgen, it could be that rust-bindgen is generating architecture specific code. According to rust docs, the C Char type could be i8 or u8, depending on architecture.

https://doc.rust-lang.org/core/ffi/type.c_char.html

Which makes sense when this error only shows up on the linux/arm64 platform.

The fix is to replace the hardcoded u8/i8 with `std::os::raw::c_char`, and let the compiler decide the type to use at compile time.