### PR TITLE
wolfssl-sys: Omit semver metadata from oqs-sys dependency.

### DIFF
--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -16,7 +16,7 @@ autotools = "0.2"
 build-target = "0.4.0"
 
 [dependencies.oqs-sys]
-version = "0.9.1+liboqs-0.9.0"
+version = "0.9.1"
 default-features = false
 features = ["kems", "sigs"]
 optional = true


### PR DESCRIPTION
This removes the warning:

```
warning: wolfssl-rs/wolfssl-sys/Cargo.toml: version requirement `0.9.1+liboqs-0.9.0` for dependency `oqs-sys` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion
```

Since the metadata is ignored there is no change to `Cargo.lock` or to what is actually built.

Note that this is ommitted in e.g. https://crates.io/crates/oqs-sys and would be omitted by `cargo add -p wolfssl-sys oqs-sys` too.