### PR TITLE
deny.toml: Update for advisories and licenses stanzas to version 2

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,24 +1,14 @@
 [advisories]
+version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "deny"
 yanked = "deny"
-notice = "deny"
 ignore = [
     #"RUSTSEC-0000-0000",
 ]
-# * None - CVSS Score 0.0
-# * Low - CVSS Score 0.1 - 3.9
-# * Medium - CVSS Score 4.0 - 6.9
-# * High - CVSS Score 7.0 - 8.9
-# * Critical - CVSS Score 9.0 - 10.0
-severity-threshold = "High"
 
 [licenses]
-default = "deny"
-copyleft = "deny"
-unlicensed = "deny"
+version = 2
 allow = [
     "MIT",
     "Apache-2.0",
@@ -26,7 +16,6 @@ allow = [
     "BSD-3-Clause",
     "ISC",
 ]
-allow-osi-fsf-free = "neither"
 confidence-threshold = 0.8
 exceptions = [
     { name = "wolfssl", allow = ["GPL-2.0"], version = "*" },


### PR DESCRIPTION
Several fields were deprecated and causing warnings, out settings match the new default behaviour anyway.

See https://github.com/EmbarkStudios/cargo-deny/pull/611 for more.