### PR TITLE
CVPN-753: Add public api for retrieving ErrorKind

### DIFF
--- a/wolfssl/src/context.rs
+++ b/wolfssl/src/context.rs
@@ -547,7 +547,7 @@ mod tests {
     }
 
     #[test_case(true, true => true)]
-    #[test_case(true, false => panics "Fatal(FatalError")]
+    #[test_case(true, false => panics "Fatal(Other { what:")]
     #[test_case(false, false => false)]
     #[test_case(false, true => false)]
     fn try_when(whether: bool, ok: bool) -> bool {
@@ -567,7 +567,7 @@ mod tests {
     }
 
     #[test_case(Some(true) => true)]
-    #[test_case(Some(false) => panics "Fatal(FatalError")]
+    #[test_case(Some(false) => panics "Fatal(Other { what:")]
     #[test_case(None => false)]
     fn try_some(whether: Option<bool>) -> bool {
         let mut called = false;

--- a/wolfssl/src/lib.rs
+++ b/wolfssl/src/lib.rs
@@ -18,7 +18,7 @@ pub use context::*;
 pub use rng::*;
 pub use ssl::*;
 
-pub use error::{Error, Poll, Result};
+pub use error::{Error, ErrorKind, Poll, Result};
 
 #[cfg(feature = "debug")]
 pub use debug::*;


### PR DESCRIPTION
Add abstraction `FatalErrorKind` over wolfssl error code and add a public api for retrieving it