### PR TITLE
Remove the `Mutex` from `WolfsslPointer` in `Session::ssl`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,12 +87,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
-
-[[package]]
 name = "autotools"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,16 +346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,29 +422,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.5",
-]
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,15 +465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -570,22 +522,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "smallvec"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -864,7 +804,6 @@ dependencies = [
  "bytes",
  "env_logger",
  "log",
- "parking_lot",
  "test-case",
  "thiserror",
  "tokio",

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -16,7 +16,6 @@ debug = ["wolfssl-sys/debug"] # Note that application code must also call wolfss
 [dependencies]
 bytes = "1"
 log = "0.4"
-parking_lot = "0.12.1"
 thiserror = "1.0"
 wolfssl-sys = { path = "../wolfssl-sys", version = "1.0.0" }
 

--- a/wolfssl/src/callback.rs
+++ b/wolfssl/src/callback.rs
@@ -25,7 +25,7 @@ pub trait IOCallbacks {
     /// the number of bytes actually received. If the operation would
     /// block [`std::io::ErrorKind::WouldBlock`] then return
     /// [`IOCallbackResult::WouldBlock`].
-    fn recv(&self, buf: &mut [u8]) -> IOCallbackResult<usize>;
+    fn recv(&mut self, buf: &mut [u8]) -> IOCallbackResult<usize>;
 
     /// Called when WolfSSL wishes to send some data
     ///
@@ -33,5 +33,5 @@ pub trait IOCallbacks {
     /// return the number of bytes actually consumed. If the operation would
     /// block [`std::io::ErrorKind::WouldBlock`] then return
     /// [`IOCallbackResult::WouldBlock`].
-    fn send(&self, buf: &[u8]) -> IOCallbackResult<usize>;
+    fn send(&mut self, buf: &[u8]) -> IOCallbackResult<usize>;
 }


### PR DESCRIPTION
Instead take `&mut self` in `Session`'s methods, this allows the consumers to choose to use an `&mut` session themselves and avoid locking, but does not preclude them using a `Mutex` themselves.

With this we now know that there can be no parallel code paths which might hit an `IOCallback` method, therefore we can make those receive `&mut self` (since the callback type is owned by the session).

Together with the use of `&mut self` in the various `Session` methods this now makes `io_cb_mut()` usable by consuming applications to access their IOCallback implementation's state knowing that nothing else can be touching it.