### PR TITLE
wolfssl: Expose postquantum as a cargo feature

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -66,6 +66,7 @@ build-crate:
 lint:
     FROM +copy-src
     DO lib-rust+CARGO --args="clippy --all-features --all-targets -- -D warnings"
+    DO lib-rust+CARGO --args="clippy --no-default-features --all-targets -- -D warnings"
     ENV RUSTDOCFLAGS="-D warnings"
     DO lib-rust+CARGO --args="doc --all-features --document-private-items"
 

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/expressvpn/wolfssl-rs"
 keywords = ["wolfssl", "vpn", "lightway", "post-quantum", "cryptography"]
 
 [features]
-default = []
+default = ["postquantum"]
+postquantum = ["wolfssl-sys/postquantum"]
 debug = ["wolfssl-sys/debug"] # Note that application code must also call wolfssl::enable_debugging(true)
 
 [dependencies]
@@ -17,7 +18,7 @@ bytes = "1"
 log = "0.4"
 parking_lot = "0.12.1"
 thiserror = "1.0"
-wolfssl-sys = { path = "../wolfssl-sys", features = ["postquantum"] }
+wolfssl-sys = { path = "../wolfssl-sys" }
 
 [dev-dependencies]
 async-trait = "0.1.73"

--- a/wolfssl/src/lib.rs
+++ b/wolfssl/src/lib.rs
@@ -229,10 +229,13 @@ pub enum CurveGroup {
     EccX25519,
 
     /// `WOLFSSL_P256_KYBER_LEVEL1`
+    #[cfg(feature = "postquantum")]
     P256KyberLevel1,
     /// `WOLFSSL_P384_KYBER_LEVEL3`
+    #[cfg(feature = "postquantum")]
     P384KyberLevel3,
     /// `WOLFSSL_P521_KYBER_LEVEL5`
+    #[cfg(feature = "postquantum")]
     P521KyberLevel5,
 }
 
@@ -242,8 +245,11 @@ impl CurveGroup {
         match self {
             EccSecp256R1 => wolfssl_sys::WOLFSSL_ECC_SECP256R1,
             EccX25519 => wolfssl_sys::WOLFSSL_ECC_X25519,
+            #[cfg(feature = "postquantum")]
             P256KyberLevel1 => wolfssl_sys::WOLFSSL_P256_KYBER_LEVEL1,
+            #[cfg(feature = "postquantum")]
             P384KyberLevel3 => wolfssl_sys::WOLFSSL_P384_KYBER_LEVEL3,
+            #[cfg(feature = "postquantum")]
             P521KyberLevel5 => wolfssl_sys::WOLFSSL_P521_KYBER_LEVEL5,
         }
     }


### PR DESCRIPTION
... default enabled, but this allows omitting the liboqs dependency chain if desired.

To ensure the build works we lint both with all features and with no features.