### PR TITLE
CVPN-249 Release wolfssl-sys v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "wolfssl-sys"
-version = "0.1.16"
+version = "1.0.0"
 dependencies = [
  "autotools",
  "bindgen 0.69.4",

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ If you are not a member of ExpressVPN, you may set up your own Earthly satellite
 
 This repository is a monorepo for two crates: `wolfssl-sys` and `wolfssl`. They should __always__ be released together. Since `wolfssl` depends on `wolfssl-sys`, they should be released in the below order:
 
-1. Bump the version in `wolfssl-sys` and release it (Follow the section [Releasing a Single Crate](#releasing-a-single-crate))
-1. Bump the version in `wolfssl`, update the dependency `wolfssl-sys` to the latest version, and release it (same procedure as above)
+1. Bump the crate version `wolfssl-sys`, update the version specified under `dependencies` in the `wolfssl` crate, and release it (Follow the section [Releasing a Single Crate](#releasing-a-single-crate))
+1. Bump the crate version `wolfssl` and release it (same procedure as above)
 
 
 ## Releasing a Single Crate

--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-sys"
-version = "0.1.16"
+version = "1.0.0"
 edition = "2021"
 authors = ["pete.m@expressvpn.com"]
 license = "GPL-2.0"

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -18,7 +18,7 @@ bytes = "1"
 log = "0.4"
 parking_lot = "0.12.1"
 thiserror = "1.0"
-wolfssl-sys = { path = "../wolfssl-sys", version = "0.1.15" }
+wolfssl-sys = { path = "../wolfssl-sys", version = "1.0.0" }
 
 [dev-dependencies]
 async-trait = "0.1.73"


### PR DESCRIPTION
This PR will release wolfssl-sys to version v1.0.0, as well as update the release documentation.

## Description

The cargo documentation [1] is slightly misleading. It was understood that when both the path and the version are specified for a crate, the version attribute will be ignored when not publishing, but in fact it is not ignored. After re-reading the docs, its behaviour is:

During local/ci:
- Cargo will follow the path to locate the crate
- After the crate is located, the crate's version will be validated against the one specified

During publish:
- Cargo will only refer to the version in crates.io

Due to this updated understanding, we need to change our release instruction to update both the `wolfssl-sys` crate version and the version specified under the dependencies in the `wolfssl` crate.

[1]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] The correct base branch is being used, if not `main`