### PR TITLE
GHA: Pass GH token to `earthly/actions-setup`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
       - uses: earthly/actions-setup@v1
         with:
           version: v0.8.3
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -43,6 +44,7 @@ jobs:
       - uses: earthly/actions-setup@v1
         with:
           version: v0.8.3
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
         with:
           submodules: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,7 @@ jobs:
       - uses: earthly/actions-setup@v1
         with:
           version: v0.8.3
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
         with:
           submodules: true


### PR DESCRIPTION
... this avoids rate-limiting.