### PR TITLE
GHA: Coordinate wolfssl and wolfssl-sys releases

### DIFF
--- a/.github/actions/check-dependencies/action.yml
+++ b/.github/actions/check-dependencies/action.yml
@@ -1,0 +1,95 @@
+name: "Validate wolfssl-sys dependency version"
+
+outputs:
+  dependency_status:
+    description: "Is wolfssl's versioned dependency on wolfssl-sys up to date [released, pending, unreleased, out-of-date]"
+    value: ${{ steps.validate_dependency.outputs.status }}
+  dependency_version:
+    description: "Current value of wolfssl's versioned dependency on wolfssl-sys"
+    value: ${{ steps.get-dep.outputs.version }}
+  wolfssl_sys_release_status:
+    description: "Current wolfssl-sys status: [released, pending, unreleased]"
+    value: ${{ steps.validate_sys_release.outputs.status }}
+  wolfssl_sys_release_version:
+    description: "Current wolfssl-sys wolfssl release"
+    value: ${{ steps.get-sys-release.outputs.version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get wolfssl-sys current release version
+      id: get-sys-release
+      shell: bash
+      run: |
+        VER=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "wolfssl-sys") | .version')
+        echo version=${VER} >> $GITHUB_OUTPUT
+    - name: Get wolfssl-sys current release treesha
+      id: get-sys-release-treesha
+      shell: bash
+      run: |
+        TAG="wolfssl-sys-${{ steps.get-sys-release.outputs.version }}"
+        if ! git fetch origin --depth=1 tag "$TAG" ; then
+            echo "tag $TAG not found, assuming pending release"
+            echo sha=pending >> $GITHUB_OUTPUT
+            exit 0
+        fi
+
+        TREESHA=$(git ls-tree --object-only $TAG wolfssl-sys)
+        echo TREESHA=$TREESHA
+        echo sha=${TREESHA} >> $GITHUB_OUTPUT
+
+    - name: Get latest sys treesha
+      id: get-sys-latest-treesha
+      shell: bash
+      run: |
+        TREESHA=$(git ls-tree --object-only HEAD wolfssl-sys)
+        echo TREESHA=$TREESHA
+        echo sha=${TREESHA} >> $GITHUB_OUTPUT
+
+    - name: Get wolfssl->wolfssl-sys dependency version
+      id: get-dep
+      shell: bash
+      run: |
+        # DEP is e.g. ^1.0.0, which is the only form we expect to see
+        DEP=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "wolfssl") | .dependencies[] | select(.name == "wolfssl-sys") | .req')
+
+        case $DEP in
+        ^*)
+            echo version=${DEP#^} >> $GITHUB_OUTPUT
+            ;;
+        *)
+          echo "Unexpected dependency format: $DEP"
+          exit 1
+        esac
+
+    - name: Validate wolfssl-sys is released
+      id: validate_sys_release
+      shell: bash
+      run: |
+        if [ ${{ steps.get-sys-release-treesha.outputs.sha }} != "pending" ] ; then
+            echo "current wolfssl-sys release has tree sha ${{ steps.get-sys-release-treesha.outputs.sha }}" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "latest wolfssl-sys has tree sha ${{ steps.get-sys-latest-treesha.outputs.sha }}" >> $GITHUB_STEP_SUMMARY
+
+        if [ ${{ steps.get-sys-release-treesha.outputs.sha }} = "pending" ] ; then
+            echo "current wolfssl-sys release ${{ steps.get-sys-release.outputs.version }} is pending (tag not found)" >> $GITHUB_STEP_SUMMARY
+            echo "status=pending" >> $GITHUB_OUTPUT
+        elif [ ${{ steps.get-sys-release-treesha.outputs.sha }} = ${{ steps.get-sys-latest-treesha.outputs.sha }} ] ; then
+            echo "current wolfssl-sys release ${{ steps.get-sys-release.outputs.version }} is up to date" >> $GITHUB_STEP_SUMMARY
+            echo status=released >> $GITHUB_OUTPUT
+        else
+            echo "wolfssl-sys has unreleased changes" >> $GITHUB_STEP_SUMMARY
+            echo status=unreleased >> $GITHUB_OUTPUT
+        fi
+
+    - name: Validate wolfssl->wolfssl-sys dependency
+      id: validate_dependency
+      shell: bash
+      run: |
+        if [ ${{ steps.get-dep.outputs.version }} = ${{ steps.get-sys-release.outputs.version }} ] ; then
+            echo "wolfssl depends on latest wolfssl-sys ${{ steps.get-dep.outputs.version }}, which is ${{ steps.validate_sys_release.outputs.status }}" >> $GITHUB_STEP_SUMMARY
+            echo status=${{ steps.validate_sys_release.outputs.status }} >> $GITHUB_OUTPUT
+        else
+            echo "wolfssl depends on outdated wolfssl-sys ${{ steps.get-dep.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+            echo status=out-of-date >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
             const is_release_label_attached = attached_labels.find(label => label.name == 'release') !== undefined
             core.setOutput('is_release_label_attached', is_release_label_attached)
             core.setOutput('issue_number', issue_number)
+
   release:
     runs-on: ubuntu-latest
     needs: check_label
@@ -54,6 +55,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - uses: ./.github/actions/check-dependencies
+        id: check_dependencies
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
@@ -109,6 +114,11 @@ jobs:
             const is_dry_run = !is_merge_event
             console.log("Dry run status is:", is_dry_run)
 
+            console.log("wolfssl-sys release version: ${{ steps.check_dependencies.outputs.wolfssl_sys_release_version }}")
+            console.log("wolfssl-sys release status: ${{ steps.check_dependencies.outputs.wolfssl_sys_release_status }}")
+            console.log("wolfssl to sys dependency version: ${{ steps.check_dependencies.outputs.dependency_version }}")
+            console.log("wolfssl to sys dependency status: ${{ steps.check_dependencies.outputs.dependency_status }}")
+
             const crate_definitions = await globby("*/Cargo.toml")
 
             const crates_to_publish = []
@@ -121,8 +131,15 @@ jobs:
               const version_on_crate_io = (await get_crate_details(name)).crate.max_version
 
               if (version_on_file != version_on_crate_io) {
-                console.log("Crate", name, "need publishing")
-                crates_to_publish.push({ name, version_on_file, version_on_crate_io })
+                console.log("Crate", name, "needs publishing")
+
+                if (name == "wolfssl" && "${{ steps.check_dependencies.outputs.dependency_status }})" != "released") {
+                  console.log("Cannot release wolfssl with dependency on ${{ steps.check_dependencies.outputs.dependency_status }} wolfssl-sys")
+                  crates_to_publish.push({ name, version_on_file, version_on_crate_io, ok_to_release: ":negative_squared_cross_mark: dependency on ${{ steps.check_dependencies.outputs.dependency_status }} wolfssl-sys" })
+                  continue
+                }
+
+                crates_to_publish.push({ name, version_on_file, version_on_crate_io, ok_to_release: ":white_check_mark:" })
 
                 run_command_stream(["earthly", "--push", "--ci", "--org", "expressvpn", "--satellite", "wolfssl-rs", "--secret", "CARGO_REGISTRY_TOKEN", "+publish", `--PACKAGE=${name}`, `--DRY_RUN=${is_dry_run}`])
                 if (!is_dry_run) {
@@ -134,7 +151,7 @@ jobs:
             }
 
             const crates_to_publish_table_rendered = crates_to_publish.map(item =>
-              `| \`${item.name}\` | ${item.version_on_crate_io} | **${item.version_on_file}** |`
+              `| \`${item.name}\` | ${item.version_on_crate_io} | **${item.version_on_file}** | ${item.ok_to_release} |`
             ).join("\n")
             core.setOutput('crates_to_publish_table_rendered', crates_to_publish_table_rendered)
 
@@ -162,7 +179,7 @@ jobs:
           body: |
             # :rocket: Release Plan
 
-            | Crate | Previous version | New version |
-            |--|--|--|
+            | Crate | Previous version | New version | OK to release |
+            |--|--|--|--|
             ${{ steps.process_release.outputs.crates_to_publish_table_rendered }}
           edit-mode: replace

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -135,11 +135,11 @@ jobs:
 
                 if (name == "wolfssl" && "${{ steps.check_dependencies.outputs.dependency_status }})" != "released") {
                   console.log("Cannot release wolfssl with dependency on ${{ steps.check_dependencies.outputs.dependency_status }} wolfssl-sys")
-                  crates_to_publish.push({ name, version_on_file, version_on_crate_io, ok_to_release: ":negative_squared_cross_mark: dependency on ${{ steps.check_dependencies.outputs.dependency_status }} wolfssl-sys" })
+                  crates_to_publish.push({ name, version_on_file, version_on_crate_io, release_status: ":no_entry: Blocked", comment: "dependency on ${{ steps.check_dependencies.outputs.dependency_status }} wolfssl-sys" })
                   continue
                 }
 
-                crates_to_publish.push({ name, version_on_file, version_on_crate_io, ok_to_release: ":white_check_mark:" })
+                crates_to_publish.push({ name, version_on_file, version_on_crate_io, release_status: ":white_check_mark: Release", comment: "" })
 
                 run_command_stream(["earthly", "--push", "--ci", "--org", "expressvpn", "--satellite", "wolfssl-rs", "--secret", "CARGO_REGISTRY_TOKEN", "+publish", `--PACKAGE=${name}`, `--DRY_RUN=${is_dry_run}`])
                 if (!is_dry_run) {
@@ -147,11 +147,12 @@ jobs:
                 }
               } else {
                 console.log("Crate", name, "does not need publishing")
+                crates_to_publish.push({ name, version_on_file, version_on_crate_io, release_status: ":negative_squared_cross_mark: No release", comment: "" })
               }
             }
 
             const crates_to_publish_table_rendered = crates_to_publish.map(item =>
-              `| \`${item.name}\` | ${item.version_on_crate_io} | **${item.version_on_file}** | ${item.ok_to_release} |`
+              `| \`${item.name}\` | ${item.version_on_crate_io} | **${item.version_on_file}** | ${item.release_status} | ${item.comment} | `
             ).join("\n")
             core.setOutput('crates_to_publish_table_rendered', crates_to_publish_table_rendered)
 
@@ -179,7 +180,7 @@ jobs:
           body: |
             # :rocket: Release Plan
 
-            | Crate | Previous version | New version | OK to release |
-            |--|--|--|--|
+            | Crate | Previous version | New version | Release? | Comment |
+            |--|--|--|--|--|
             ${{ steps.process_release.outputs.crates_to_publish_table_rendered }}
           edit-mode: replace

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,6 +121,7 @@ jobs:
 
             const crate_definitions = await globby("*/Cargo.toml")
 
+            let blocked_crates = 0
             const crates_to_publish = []
             for (crate_definition of crate_definitions) {
               console.log(`Processing ${crate_definition}`)
@@ -136,6 +137,7 @@ jobs:
                 if (name == "wolfssl" && "${{ steps.check_dependencies.outputs.dependency_status }})" != "released") {
                   console.log("Cannot release wolfssl with dependency on ${{ steps.check_dependencies.outputs.dependency_status }} wolfssl-sys")
                   crates_to_publish.push({ name, version_on_file, version_on_crate_io, release_status: ":no_entry: Blocked", comment: "dependency on ${{ steps.check_dependencies.outputs.dependency_status }} wolfssl-sys" })
+                  blocked_crates++
                   continue
                 }
 
@@ -155,6 +157,7 @@ jobs:
               `| \`${item.name}\` | ${item.version_on_crate_io} | **${item.version_on_file}** | ${item.release_status} | ${item.comment} | `
             ).join("\n")
             core.setOutput('crates_to_publish_table_rendered', crates_to_publish_table_rendered)
+            core.setOutput('nr_crates_blocked_from_releasing', blocked_crates)
 
       - uses: peter-evans/find-comment@v3
         id: fc
@@ -184,3 +187,9 @@ jobs:
             |--|--|--|--|--|
             ${{ steps.process_release.outputs.crates_to_publish_table_rendered }}
           edit-mode: replace
+
+      - if: ${{ steps.process_release.outputs.nr_crates_blocked_from_releasing > 0 }}
+        name: Fail release on blocked releases
+        uses: actions/github-script@v7
+        with:
+          script: core.setFailed('Unable to release all required crates')

--- a/README.md
+++ b/README.md
@@ -68,15 +68,27 @@ If you are not a member of ExpressVPN, you may set up your own Earthly satellite
 
 This repository is a monorepo for two crates: `wolfssl-sys` and `wolfssl`. It is required when releasing `wolfssl` that it depends on an version of `wolfssl-sys` which is up to date with `main`.
 
-If `wolfssl-sys` has unreleased changes:
+There are four possible states for `wolfssl`'s dependency on `wolfssl-sys`:
 
-1. Bump the crate version `wolfssl-sys`
+| State         | Description                                                               |
+|---------------|---------------------------------------------------------------------------|
+| `released`    | `wolfssl` depends on the latest, most up to date release of `wolfssl-sys` |
+| `pending`     | `wolfssl` depends on a pending release of `wolfssl-sys`                   |
+| `unreleased`  | `wolfssl-sys` has changes which must be released                          |
+| `out-of-date` | `wolfssl` depends on an old version of `wolfssl-sys`                      |
+
+If state is `out-of-date` or `unreleased` then:
+
+1. Bump the crate version in `wolfssl-sys/Cargo.toml`
 1. Update the version specified under `dependencies` in the `wolfssl` crate
+
+The state will now be `pending` (or it already was) so:
+
 1. Release `wolfssl-sys` (Follow the section [Releasing a Single Crate](#releasing-a-single-crate))
 
 Once the most recent `wolfssl-sys` is released and `wolfssl` depends on it then `wolfssl` can be released:
 
-1. Bump the crate version `wolfssl`
+1. Bump the crate version in `wolfssl/Cargo.toml`
 1. Release `wolfssl` (Follow the section [Releasing a Single Crate](#releasing-a-single-crate))
 
 ## Releasing a Single Crate

--- a/README.md
+++ b/README.md
@@ -66,11 +66,18 @@ If you are not a member of ExpressVPN, you may set up your own Earthly satellite
 
 # Releasing
 
-This repository is a monorepo for two crates: `wolfssl-sys` and `wolfssl`. They should __always__ be released together. Since `wolfssl` depends on `wolfssl-sys`, they should be released in the below order:
+This repository is a monorepo for two crates: `wolfssl-sys` and `wolfssl`. It is required when releasing `wolfssl` that it depends on an version of `wolfssl-sys` which is up to date with `main`.
 
-1. Bump the crate version `wolfssl-sys`, update the version specified under `dependencies` in the `wolfssl` crate, and release it (Follow the section [Releasing a Single Crate](#releasing-a-single-crate))
-1. Bump the crate version `wolfssl` and release it (same procedure as above)
+If `wolfssl-sys` has unreleased changes:
 
+1. Bump the crate version `wolfssl-sys`
+1. Update the version specified under `dependencies` in the `wolfssl` crate
+1. Release `wolfssl-sys` (Follow the section [Releasing a Single Crate](#releasing-a-single-crate))
+
+Once the most recent `wolfssl-sys` is released and `wolfssl` depends on it then `wolfssl` can be released:
+
+1. Bump the crate version `wolfssl`
+1. Release `wolfssl` (Follow the section [Releasing a Single Crate](#releasing-a-single-crate))
 
 ## Releasing a Single Crate
 


### PR DESCRIPTION
When releasing `wolfssl` from `main` we want to be sure it depends on the most recent `wolfssl-sys` changes in `main`.

For usage from git this is fine since the dependency involves a `path` key. This is also what we actually test in CI.

For usage from crates.io this means we want the `version` field to point to the latest version of the code -- which may mean we need to release `wolfssl-sys` first if there are unreleased changes there.

The SHA of the tree object of the `wolfssl-sys` subtree changes precisely when `wolfssl-sys` is changed, so we can match using that by comparing main to the tagged release.

There are four states:
* `released`: `wolfssl` depends on a release of `wolfssl-sys` which contains the most recent code -> go ahead and release
* `out-of-date`: `wolfssl` depends on a release of `wolfssl-sys` which is not the most recent -> block the release
* `pending`: `wolfssl` depends on a release of `wolfssl-sys` which has not been released (meaning the git tag corresponding to `wolfssl-sys/Cargo.toml` version does not exist) -> block the release
* `unreleased`: `wolfssl` depends on latest release of `wolfssl-sys` but there are changes in git since that release was made (git tag corresponding to the version is behind latest code in the `wolfssl-sys` subtree) -> block the release


These are reflected in the `dependency_status` output.

I think if we could control the order in which the `process_release` step considers the crates so that it finds (and releases) `wolfssl-sys` before `wolfssl` then the `pending` result would be non-blocking, and we could potentially release both crates with a single PR.  instead of one by one. I think we should land this change first and ensure that it works though.