### PR TITLE
Release `wolfssl-sys` v1.1.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global rule:
-* @xv-pete-m @expressvpn-brendan-h @kp-mariappan-ramasamy @xv-ian-c
+* @expressvpn/expressvpn-lightway-codeowners

--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-sys"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 authors = ["lightway-developers@expressvpn.com"]
 license = "GPL-2.0"

--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wolfssl-sys"
 version = "1.0.0"
 edition = "2021"
-authors = ["pete.m@expressvpn.com"]
+authors = ["lightway-developers@expressvpn.com"]
 license = "GPL-2.0"
 readme = "README.md"
 description = "System bindings for WolfSSL"

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wolfssl"
 version = "1.0.0"
 edition = "2021"
-authors = ["pete.m@expressvpn.com", "pang.t@expressvpn.com", "brendan.h@expressvpn.com"]
+authors = ["lightway-developers@expressvpn.com"]
 license = "GPL-2.0"
 description = "High-level bindings for WolfSSL"
 repository = "https://github.com/expressvpn/wolfssl-rs"

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -17,7 +17,7 @@ debug = ["wolfssl-sys/debug"] # Note that application code must also call wolfss
 bytes = "1"
 log = "0.4"
 thiserror = "1.0"
-wolfssl-sys = { path = "../wolfssl-sys", version = "1.0.0" }
+wolfssl-sys = { path = "../wolfssl-sys", version = "1.1.0" }
 
 [dev-dependencies]
 async-trait = "0.1.73"


### PR DESCRIPTION
This releases the changes from #142 as well as being the first time we will excercise the release machinery after #147.

I also took the opportunity to refresh CODEOWNERS and the author fields in the crates.