### PR TITLE
Release with fresh `Cargo.lock`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,20 @@ jobs:
         with:
           submodules: true
 
+      - name: Check Cargo.lock is up-to-date
+        shell: bash
+        run: |
+          cargo update --workspace
+          diff=$(git status --porcelain --ignore-submodules=none -- Cargo.lock)
+          if [ -n "$diff" ] ; then
+            echo "ERROR: git tree is dirty!"
+            echo
+            echo "$diff"
+            echo
+            git --no-pager diff -- $paths
+            exit 1
+          fi
+
       - uses: ./.github/actions/check-dependencies
         id: check_dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "wolfssl"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "wolfssl-sys"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "autotools",
  "bindgen 0.69.4",


### PR DESCRIPTION
#148 and #150 missed updating `Cargo.lock` do so and add a CI step so it cannot be forgotten in the future