### PR TITLE
Release both crates via a single release PR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,11 +133,13 @@ jobs:
             console.log("wolfssl to sys dependency version: ${{ steps.check_dependencies.outputs.dependency_version }}")
             console.log("wolfssl to sys dependency status: ${{ steps.check_dependencies.outputs.dependency_status }}")
 
-            const crate_definitions = await globby("*/Cargo.toml")
+            const crates = ["wolfssl-sys", "wolfssl"]
 
             let blocked_crates = 0
             const crates_to_publish = []
-            for (crate_definition of crate_definitions) {
+            for (crate of crates) {
+              const crate_definition = crate + "/Cargo.toml"
+
               console.log(`Processing ${crate_definition}`)
 
               const data = toml.parse(fs.readFileSync(crate_definition, 'utf8'))
@@ -148,14 +150,17 @@ jobs:
               if (version_on_file != version_on_crate_io) {
                 console.log("Crate", name, "needs publishing")
 
-                if (name == "wolfssl" && "${{ steps.check_dependencies.outputs.dependency_status }}" != "released") {
-                  console.log("Cannot release wolfssl with dependency on ${{ steps.check_dependencies.outputs.dependency_status }} wolfssl-sys")
-                  crates_to_publish.push({ name, version_on_file, version_on_crate_io, release_status: ":no_entry: Blocked", comment: "dependency on ${{ steps.check_dependencies.outputs.dependency_status }} wolfssl-sys" })
-                  blocked_crates++
-                  continue
+                if (name == "wolfssl") {
+                  if(!["pending", "released"].includes("${{ steps.check_dependencies.outputs.dependency_status }}")) {
+                    console.log("Cannot release wolfssl with dependency on ${{ steps.check_dependencies.outputs.dependency_status }} wolfssl-sys")
+                    crates_to_publish.push({ name, version_on_file, version_on_crate_io, release_status: ":no_entry: Blocked", comment: "dependency on ${{ steps.check_dependencies.outputs.dependency_status }} wolfssl-sys" })
+                    blocked_crates++
+                    continue
+                  }
+                  crates_to_publish.push({ name, version_on_file, version_on_crate_io, release_status: ":white_check_mark: Release", comment: "dependency on ${{ steps.check_dependencies.outputs.dependency_status }} wolfssl-sys" })
+                } else {
+                  crates_to_publish.push({ name, version_on_file, version_on_crate_io, release_status: ":white_check_mark: Release", comment: "" })
                 }
-
-                crates_to_publish.push({ name, version_on_file, version_on_crate_io, release_status: ":white_check_mark: Release", comment: "" })
 
                 run_command_stream(["earthly", "--push", "--ci", "--org", "expressvpn", "--satellite", "wolfssl-rs", "--secret", "CARGO_REGISTRY_TOKEN", "+publish", `--PACKAGE=${name}`, `--DRY_RUN=${is_dry_run}`])
                 if (!is_dry_run) {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "wolfssl-sys"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "autotools",
  "bindgen 0.69.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,7 +798,7 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "wolfssl"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/README.md
+++ b/README.md
@@ -77,27 +77,54 @@ There are four possible states for `wolfssl`'s dependency on `wolfssl-sys`:
 | `unreleased`  | `wolfssl-sys` has changes which must be released                          |
 | `out-of-date` | `wolfssl` depends on an old version of `wolfssl-sys`                      |
 
+If state is `released` then `wolfssl` can be released without releasing a new version of `wolfssl-sys`.
+
 If state is `out-of-date` or `unreleased` then:
 
-1. Bump the crate version in `wolfssl-sys/Cargo.toml`
+1. Bump the crate version in `wolfssl-sys/Cargo.toml`, following semantic versioning.
 1. Update the version specified under `dependencies` in the `wolfssl` crate
 
-The state will now be `pending` (or it already was) so:
+The state will now be (or already was) either `pending` or `released` so we can release:
 
-1. Release `wolfssl-sys` (Follow the section [Releasing a Single Crate](#releasing-a-single-crate))
-
-Once the most recent `wolfssl-sys` is released and `wolfssl` depends on it then `wolfssl` can be released:
-
-1. Bump the crate version in `wolfssl/Cargo.toml`
-1. Release `wolfssl` (Follow the section [Releasing a Single Crate](#releasing-a-single-crate))
-
-## Releasing a Single Crate
-
-A GitHub Workflow is set up to automate the release of crates in this repo. Upon a release, it will create a release in GitHub and Crates.io
-
-To create a new release, follow the below steps:
-
-1. Bump the version in `<crate-name>/Cargo.toml`. We follow the semantic versioning pattern when deciding a new version number
+1. Bump the crate version in `wolfssl/Cargo.toml`, following semantic versioning.
 1. Open a PR, attach the `release` label to the PR
-1. Observe that a comment is add to the PR, indicating the current version and the upcoming version
-1. Merge the PR, a new version should be released to both GitHub and Crates.io
+1. Observe that a comment is add to the PR, indicating the current version(s) and the upcoming version(s)
+1. Merge the PR, the new version(s) should be released to both GitHub and Crates.io
+
+
+```mermaid
+flowchart TD
+    Start((Start))
+
+    Released([Released])
+    Pending([Pending])
+    Unreleased([Unreleased])
+    OutOfDate([Out-of-date])
+
+    BumpWolfsslSysVersion[Update version in wolfssl-sys/Cargo.toml]
+    BumpWolfsslVersion[Update version in wolfssl/Cargo.toml]
+    BumpWolfsslSysDependency["
+      Update dependency from wolfssl on wolfssl-sys
+      in wolfssl/Cargo.toml to new version
+    "]
+    RaiseReleasePR[Raise Release PR]
+
+    Complete((Done))
+
+    Start --> Released
+    Start --> Pending
+    Start --> Unreleased
+    Start --> OutOfDate
+
+    Released --> BumpWolfsslVersion
+    Pending --> BumpWolfsslVersion
+
+    Unreleased --> BumpWolfsslSysVersion
+    OutOfDate --> BumpWolfsslSysDependency
+
+    BumpWolfsslSysVersion --> BumpWolfsslSysDependency
+
+    BumpWolfsslSysDependency --> Pending
+    BumpWolfsslVersion --> RaiseReleasePR
+    RaiseReleasePR --> Complete
+```

--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-sys"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = ["lightway-developers@expressvpn.com"]
 license = "GPL-2.0"

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = ["lightway-developers@expressvpn.com"]
 license = "GPL-2.0"

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -17,7 +17,7 @@ debug = ["wolfssl-sys/debug"] # Note that application code must also call wolfss
 bytes = "1"
 log = "0.4"
 thiserror = "1.0"
-wolfssl-sys = { path = "../wolfssl-sys", version = "1.1.0" }
+wolfssl-sys = { path = "../wolfssl-sys", version = "1.1.1" }
 
 [dev-dependencies]
 async-trait = "0.1.73"


### PR DESCRIPTION
If the `wolfssl-sys` release is pending then by ensuring we process that release first we can also release `wolfssl` in the same workflow.
    
Updated the documentation and add a flowchart to try and clarify the needed steps.

[Rendered doc](https://github.com/expressvpn/wolfssl-rs/blob/3a8c664fc234dc2b35cb466945fcbc9474a11281/README.md) .