### PR TITLE
build: only include oqs features we use

### DIFF
--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -19,7 +19,7 @@ build-target = "0.4.0"
 [dependencies.oqs-sys]
 version = "0.9.1"
 default-features = false
-features = ["kems", "sigs"]
+features = ["kyber", "dilithium", "falcon"]
 optional = true
 
 [features]


### PR DESCRIPTION
This reduces the size of the .rlib file by 2 MB in release. Tested with the earthly +build-release.

One thing though, I don't think we even use dilithium or falcon at this stage but lightway-core includes them. So I'll leave it in for now.