### PR TITLE
cargo: update yanked crate `bytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,9 +179,9 @@ checksum = "832133bbabbbaa9fbdba793456a2827627a7d2b8fb96032fa1e7666d7895832b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
Error:
```
error[yanked]: detected yanked crate (try `cargo update -p bytes`)
   ┌─ /github/workspace/Cargo.lock:17:1
   │
17 │ bytes 1.6.0 registry+https://github.com/rust-lang/crates.io-index
   │ ----------------------------------------------------------------- yanked version
   │
   = bytes v1.6.0
     └── wolfssl v1.1.0
```