### PR TITLE
wolfssl-sys: disable asm optimizations for x86 builds

### DIFF
--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -144,6 +144,11 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
         }
     }
 
+    if build_target::target_arch().unwrap() == build_target::Arch::X86 {
+        // Disable all asm optmisations for x86 builds
+        conf.disable("sp-asm", None);
+    }
+
     if build_target::target_arch().unwrap() == build_target::Arch::X86_64 {
         // Enable Intel ASM optmisations
         conf.enable("intelasm", None);

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -144,28 +144,28 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
         }
     }
 
-    if build_target::target_arch().unwrap() == build_target::Arch::X86 {
-        // Disable all asm optmisations for x86 builds
-        conf.disable("sp-asm", None);
-    }
-
-    if build_target::target_arch().unwrap() == build_target::Arch::X86_64 {
-        // Enable Intel ASM optmisations
-        conf.enable("intelasm", None);
-        // Enable AES hardware acceleration
-        conf.enable("aesni", None);
-    }
-
-    if build_target::target_arch().unwrap() == build_target::Arch::AARCH64 {
-        // Enable ARM ASM optimisations
-        conf.enable("armasm", None);
-    }
-
-    if build_target::target_arch().unwrap() == build_target::Arch::ARM {
-        // Enable ARM ASM optimisations, except for android armeabi-v7a
-        if build_target::target_os().unwrap() != build_target::Os::Android {
+    match build_target::target_arch().unwrap() {
+        build_target::Arch::AARCH64 => {
+            // Enable ARM ASM optimisations
             conf.enable("armasm", None);
         }
+        build_target::Arch::ARM => {
+            // Enable ARM ASM optimisations, except for android armeabi-v7a
+            if build_target::target_os().unwrap() != build_target::Os::Android {
+                conf.enable("armasm", None);
+            }
+        }
+        build_target::Arch::X86 => {
+            // Disable sp asm optmisations which has been enabled earlier
+            conf.disable("sp-asm", None);
+        }
+        build_target::Arch::X86_64 => {
+            // Enable Intel ASM optmisations
+            conf.enable("intelasm", None);
+            // Enable AES hardware acceleration
+            conf.enable("aesni", None);
+        }
+        _ => {}
     }
 
     if build_target::target_os().unwrap() == build_target::Os::Android {


### PR DESCRIPTION
ASM optimisations can be enabled only in arm and x86_64 builds. It does not support x86.

Ref:
https://www.wolfssl.com/documentation/manuals/wolfssl/chapter02.html#-enable-sp-asm