### PR TITLE
Use correct *runtime* checks for (D)TLS 1.3

### DIFF
--- a/wolfssl/src/lib.rs
+++ b/wolfssl/src/lib.rs
@@ -137,6 +137,16 @@ impl ProtocolVersion {
             ProtocolVersion::Unknown => "unknown",
         }
     }
+
+    /// Checks if the protocol version is compatible with TLS 1.3
+    fn is_tls_13(&self) -> bool {
+        matches!(self, Self::TlsV1_3)
+    }
+
+    /// Checks if the protocol version is compatible with DTLS 1.3
+    fn is_dtls_13(&self) -> bool {
+        matches!(self, Self::DtlsV1_3)
+    }
 }
 
 /// Corresponds to the various `wolf*_{client,server}_method()` APIs
@@ -206,16 +216,6 @@ impl Protocol {
         };
 
         NonNull::new(ptr)
-    }
-
-    /// Checks if the protocol is compatible with TLS 1.3
-    fn is_tls_13(&self) -> bool {
-        matches!(self, Self::TlsClientV1_3 | Self::TlsServerV1_3)
-    }
-
-    /// Checks if the protocol is compatible with DTLS 1.3
-    fn is_dtls_13(&self) -> bool {
-        matches!(self, Self::DtlsClientV1_3 | Self::DtlsServerV1_3)
     }
 }
 

--- a/wolfssl/src/lib.rs
+++ b/wolfssl/src/lib.rs
@@ -151,7 +151,7 @@ impl ProtocolVersion {
 
 /// Corresponds to the various `wolf*_{client,server}_method()` APIs
 #[derive(Debug, Copy, Clone)]
-pub enum Protocol {
+pub enum Method {
     /// `wolfDTLS_client_method`
     DtlsClient,
     /// `wolfDTLSv1_2_client_method`
@@ -178,7 +178,7 @@ pub enum Protocol {
     TlsServerV1_3,
 }
 
-impl Protocol {
+impl Method {
     /// Converts a [`Self`] into a [`wolfssl_sys::WOLFSSL_METHOD`]
     /// compatible with [`wolfssl_sys::wolfSSL_CTX_new`]
     fn into_method_ptr(self) -> Option<NonNull<wolfssl_sys::WOLFSSL_METHOD>> {

--- a/wolfssl/src/ssl.rs
+++ b/wolfssl/src/ssl.rs
@@ -1258,7 +1258,7 @@ impl<IOCB: IOCallbacks> Drop for Session<IOCB> {
 mod tests {
     use super::*;
     use crate::{
-        context::ContextBuilder, Context, Protocol, RootCertificate, Secret, Session,
+        context::ContextBuilder, Context, Method, RootCertificate, Secret, Session,
         TLS_MAX_RECORD_SIZE,
     };
 
@@ -1349,23 +1349,23 @@ mod tests {
     }
 
     fn make_connected_clients() -> (TestClient, TestClient) {
-        make_connected_clients_with_protocol(Protocol::TlsClientV1_3, Protocol::TlsServerV1_3)
+        make_connected_clients_with_method(Method::TlsClientV1_3, Method::TlsServerV1_3)
     }
 
-    fn make_connected_clients_with_protocol(
-        client_protocol: Protocol,
-        server_protocol: Protocol,
+    fn make_connected_clients_with_method(
+        client_method: Method,
+        server_method: Method,
     ) -> (TestClient, TestClient) {
-        let client_ctx = ContextBuilder::new(client_protocol)
-            .unwrap_or_else(|e| panic!("new({client_protocol:?}): {e}"))
+        let client_ctx = ContextBuilder::new(client_method)
+            .unwrap_or_else(|e| panic!("new({client_method:?}): {e}"))
             .with_root_certificate(RootCertificate::Asn1Buffer(CA_CERT))
             .unwrap()
             .with_secure_renegotiation()
             .unwrap()
             .build();
 
-        let server_ctx = ContextBuilder::new(server_protocol)
-            .unwrap_or_else(|e| panic!("new({server_protocol:?}): {e}"))
+        let server_ctx = ContextBuilder::new(server_method)
+            .unwrap_or_else(|e| panic!("new({server_method:?}): {e}"))
             .with_certificate(Secret::Asn1Buffer(SERVER_CERT))
             .unwrap()
             .with_private_key(Secret::Asn1Buffer(SERVER_KEY))
@@ -1499,10 +1499,8 @@ mod tests {
     fn try_rehandshake() {
         INIT_ENV_LOGGER.get_or_init(env_logger::init);
 
-        let (mut client, mut server) = make_connected_clients_with_protocol(
-            Protocol::DtlsClientV1_2,
-            Protocol::DtlsServerV1_2,
-        );
+        let (mut client, mut server) =
+            make_connected_clients_with_method(Method::DtlsClientV1_2, Method::DtlsServerV1_2);
 
         assert!(client.ssl.is_secure_renegotiation_supported());
         assert!(server.ssl.is_secure_renegotiation_supported());
@@ -1556,12 +1554,12 @@ mod tests {
         assert!(!server.ssl.is_secure_renegotiation_pending());
     }
 
-    #[test_case(Protocol::TlsClientV1_3, Protocol::TlsServerV1_3; "tls1.3")]
-    #[test_case(Protocol::DtlsClientV1_3, Protocol::DtlsServerV1_3; "dtls1.3")]
-    fn try_trigger_update_keys(client: Protocol, server: Protocol) {
+    #[test_case(Method::TlsClientV1_3, Method::TlsServerV1_3; "tls1.3")]
+    #[test_case(Method::DtlsClientV1_3, Method::DtlsServerV1_3; "dtls1.3")]
+    fn try_trigger_update_keys(client: Method, server: Method) {
         INIT_ENV_LOGGER.get_or_init(env_logger::init);
 
-        let (mut client, mut server) = make_connected_clients_with_protocol(client, server);
+        let (mut client, mut server) = make_connected_clients_with_method(client, server);
 
         assert!(client.ssl.version().is_tls_13() || client.ssl.version().is_dtls_13());
         assert!(server.ssl.version().is_tls_13() || server.ssl.version().is_dtls_13());
@@ -1624,9 +1622,7 @@ mod tests {
     fn dtls_current_timeout() {
         INIT_ENV_LOGGER.get_or_init(env_logger::init);
 
-        let client_ctx = ContextBuilder::new(Protocol::DtlsClientV1_2)
-            .unwrap()
-            .build();
+        let client_ctx = ContextBuilder::new(Method::DtlsClientV1_2).unwrap().build();
 
         let mut ssl = client_ctx
             .new_session(SessionConfig::new(NoIOCallbacks))
@@ -1647,10 +1643,8 @@ mod tests {
     fn dtls_timeout(should_timeout: bool) {
         INIT_ENV_LOGGER.get_or_init(env_logger::init);
 
-        let (mut client, _server) = make_connected_clients_with_protocol(
-            Protocol::DtlsClientV1_2,
-            Protocol::DtlsServerV1_2,
-        );
+        let (mut client, _server) =
+            make_connected_clients_with_method(Method::DtlsClientV1_2, Method::DtlsServerV1_2);
 
         client
             .ssl
@@ -1702,9 +1696,7 @@ mod tests {
     fn dtls_mtu(mtu: u16) {
         INIT_ENV_LOGGER.get_or_init(env_logger::init);
 
-        let client_ctx = ContextBuilder::new(Protocol::DtlsClientV1_2)
-            .unwrap()
-            .build();
+        let client_ctx = ContextBuilder::new(Method::DtlsClientV1_2).unwrap().build();
 
         let mut ssl = client_ctx
             .new_session(SessionConfig::new(NoIOCallbacks))
@@ -1718,9 +1710,7 @@ mod tests {
         INIT_ENV_LOGGER.get_or_init(env_logger::init);
 
         // call before connection
-        let client_ctx = ContextBuilder::new(Protocol::DtlsClientV1_3)
-            .unwrap()
-            .build();
+        let client_ctx = ContextBuilder::new(Method::DtlsClientV1_3).unwrap().build();
 
         let mut ssl = client_ctx
             .new_session(SessionConfig::new(NoIOCallbacks))
@@ -1739,7 +1729,7 @@ mod tests {
         INIT_ENV_LOGGER.get_or_init(env_logger::init);
 
         // call before connection
-        let server_ctx = ContextBuilder::new(Protocol::DtlsServerV1_3)
+        let server_ctx = ContextBuilder::new(Method::DtlsServerV1_3)
             .unwrap()
             .with_certificate(Secret::Asn1Buffer(SERVER_CERT))
             .unwrap()
@@ -1791,17 +1781,17 @@ mod tests {
     #[test_case(SslVerifyMode::SslVerifyFailExceptPsk, SslVerifyMode::SslVerifyNone)]
     #[test_case(SslVerifyMode::SslVerifyFailExceptPsk, SslVerifyMode::SslVerifyPeer => panics "ASN no signer error to confirm failure")]
     fn test_client_set_verify(server_mode: SslVerifyMode, client_mode: SslVerifyMode) {
-        let client_protocol = Protocol::TlsClientV1_3;
+        let client_method = Method::TlsClientV1_3;
         // Create context without server CA certificate
-        let client_ctx = ContextBuilder::new(client_protocol)
-            .unwrap_or_else(|e| panic!("new({client_protocol:?}): {e}"))
+        let client_ctx = ContextBuilder::new(client_method)
+            .unwrap_or_else(|e| panic!("new({client_method:?}): {e}"))
             .with_secure_renegotiation()
             .unwrap()
             .build();
 
-        let server_protocol = Protocol::TlsServerV1_3;
-        let server_ctx = ContextBuilder::new(server_protocol)
-            .unwrap_or_else(|e| panic!("new({server_protocol:?}): {e}"))
+        let server_method = Method::TlsServerV1_3;
+        let server_ctx = ContextBuilder::new(server_method)
+            .unwrap_or_else(|e| panic!("new({server_method:?}): {e}"))
             .with_certificate(Secret::Asn1Buffer(SERVER_CERT))
             .unwrap()
             .with_private_key(Secret::Asn1Buffer(SERVER_KEY))


### PR DESCRIPTION
The `Protocol` type corresponds to a request to WolfSSL at setup time to take on a particular role (client vs server) supporting some set of versions (DTLS, TLS, 1.x etc). Accordingly it contains some "umbrella" versions such as
`DtlsClient` and `TlsServer` which request only "some version of" the respective protocols.
    
Therefore it does not make sense to ask "is this protocol DTLS 1.3 etc" since that would be false for `DtlsClient` even though the protocol which has actually been negotiated may well be version 1.3.
    
Move the helper methods to the `ProtocolVersion` type which reflects the runtime negotiated actual version and make use of `Session::version()` in the places which previously used the `protocol` field (which is now unneeded).

After having done this rename `Protocol` to `Method` (which is what WolfSSL actually calls the corresponding thing), in the hopes of making it harder to make the same mistake in the future.