### PR TITLE
GHA: Ensure that the CI nexus job fails if any dependent job fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,11 @@ jobs:
   ci:
     needs: [earthly, coverage]
     runs-on: ubuntu-latest
+    if: always()
     steps:
       - shell: bash
         run: |
-          echo "Build success"
+          [[ $(echo '${{ toJSON(needs) }}' | jq 'map(select(.result != "success")) | length == 0') == 'true' ]] || exit 1
   earthly:
     strategy:
       fail-fast: false


### PR DESCRIPTION
This is required to have it actually block merging PRs if one of the constituent jobs fails, since such a failure will mark the `ci` job as "skipped" which does not block merging.

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks