### PR TITLE
wolfssl-sys: Enable TLS1.3 Middlebox Compatibility

### DIFF
--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -119,7 +119,8 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
         .cflag("-DWOLFSSL_MIN_ECC_BITS=256")
         .cflag("-DUSE_CERT_BUFFERS_4096")
         .cflag("-DUSE_CERT_BUFFERS_256")
-        .cflag("-DWOLFSSL_NO_SPHINCS");
+        .cflag("-DWOLFSSL_NO_SPHINCS")
+        .cflag("-DWOLFSSL_TLS13_MIDDLEBOX_COMPAT");
 
     if cfg!(feature = "debug") {
         conf.enable("debug", None);


### PR DESCRIPTION
TLS1.3 Middlebox Compatibility (RFC8446 Appendix D.4) has been documented to help some TLS connections more reliably traverse some networks.

Ref: https://datatracker.ietf.org/doc/html/rfc8446#appendix-D.4