### PR TITLE
wolfssl: Expose Duplicate Message Error

### DIFF
--- a/wolfssl/src/error.rs
+++ b/wolfssl/src/error.rs
@@ -3,6 +3,7 @@ use std::ffi::c_int;
 use bytes::Bytes;
 use thiserror::Error;
 use wolfssl_sys::wolfSSL_ErrorCodes_DOMAIN_NAME_MISMATCH as WOLFSSL_ERROR_DOMAIN_NAME_MISMATCH;
+use wolfssl_sys::wolfSSL_ErrorCodes_DUPLICATE_MSG_E as WOLFSSL_ERROR_DUPLICATE_MSG_E;
 
 /// The `Result::Ok` for a non-blocking operation.
 #[derive(Debug)]
@@ -57,6 +58,9 @@ pub enum ErrorKind {
     /// Domain name mismatch error)
     #[error("Domain name mismatch")]
     DomainNameMismatch,
+    /// Duplicate message error
+    #[error("Duplicate message error")]
+    DuplicateMessage,
     /// All other wolfssl fatal errors
     #[error("code: {code}, what: {what}")]
     Other {
@@ -74,6 +78,7 @@ impl std::convert::From<c_int> for ErrorKind {
     fn from(code: c_int) -> Self {
         let this = match code {
             WOLFSSL_ERROR_DOMAIN_NAME_MISMATCH => Self::DomainNameMismatch,
+            WOLFSSL_ERROR_DUPLICATE_MSG_E => Self::DuplicateMessage,
             _other => Self::Other {
                 what: wolf_error_string(code as std::ffi::c_ulong),
                 code,


### PR DESCRIPTION
Exposing this presumably unhandlable error for application to restart connection as soon as possible.