### PR TITLE
Enable some additional rustc clippy lints for unsafe code

### DIFF
--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -17,7 +17,9 @@ debug = ["wolfssl-sys/debug"] # Note that application code must also call wolfss
 missing_docs = "deny"
 
 [lints.clippy]
+missing_safety_doc = "deny"
 undocumented_unsafe_blocks = "deny"
+unnecessary_safety_comment = "deny"
 
 [dependencies]
 bytes = "1"

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -16,9 +16,11 @@ debug = ["wolfssl-sys/debug"] # Note that application code must also call wolfss
 [lints.rust]
 missing_docs = "deny"
 unsafe_op_in_unsafe_fn = "deny"
+unused_unsafe = "deny"
 
 [lints.clippy]
 missing_safety_doc = "deny"
+multiple_unsafe_ops_per_block = "deny"
 undocumented_unsafe_blocks = "deny"
 unnecessary_safety_comment = "deny"
 

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -15,6 +15,7 @@ debug = ["wolfssl-sys/debug"] # Note that application code must also call wolfss
 
 [lints.rust]
 missing_docs = "deny"
+unsafe_op_in_unsafe_fn = "deny"
 
 [lints.clippy]
 missing_safety_doc = "deny"

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -13,6 +13,12 @@ default = ["postquantum"]
 postquantum = ["wolfssl-sys/postquantum"]
 debug = ["wolfssl-sys/debug"] # Note that application code must also call wolfssl::enable_debugging(true)
 
+[lints.rust]
+missing_docs = "deny"
+
+[lints.clippy]
+undocumented_unsafe_blocks = "deny"
+
 [dependencies]
 bytes = "1"
 log = "0.4"

--- a/wolfssl/src/lib.rs
+++ b/wolfssl/src/lib.rs
@@ -1,9 +1,6 @@
 //! The `wolfssl` crate is designed to be a Rust layer built on top of
 //! the `wolfssl-sys` crate (a C passthrough crate).
 
-#![warn(clippy::undocumented_unsafe_blocks)]
-#![warn(missing_docs)]
-
 mod callback;
 mod chacha20_poly1305;
 mod context;

--- a/wolfssl/src/ssl.rs
+++ b/wolfssl/src/ssl.rs
@@ -1,6 +1,6 @@
 use crate::{
     callback::{IOCallbackResult, IOCallbacks},
-    context::Context,
+    context::WolfsslPointer,
     error::{Error, Poll, PollResult, Result},
     CurveGroup, ProtocolVersion, SslVerifyMode, TLS_MAX_RECORD_SIZE,
 };
@@ -10,7 +10,6 @@ use thiserror::Error;
 
 use std::{
     ffi::{c_int, c_uchar, c_ushort, c_void},
-    ptr::NonNull,
     time::Duration,
 };
 
@@ -164,30 +163,6 @@ impl<IOCB: IOCallbacks> SessionConfig<IOCB> {
     }
 }
 
-// Wrap a valid pointer to a [`wolfssl_sys::WOLFSSL`] such that we can
-// add traits such as `Send`.
-struct WolfsslPointer(NonNull<wolfssl_sys::WOLFSSL>);
-
-impl WolfsslPointer {
-    fn as_ptr(&mut self) -> *mut wolfssl_sys::WOLFSSL {
-        self.0.as_ptr()
-    }
-}
-
-// SAFETY: Per [Library Design][] under "Thread Safety"
-//
-// > A client may share an WOLFSSL object across multiple threads but
-// > access must be synchronized, i.e., trying to read/write at the same
-// > time from two different threads with the same SSL pointer is not
-// > supported.
-//
-// This is consistent with the requirements for `Send`. The required
-// syncronization is handled by requiring `&mut self` in all relevant
-// methods.
-//
-// [Library Design]: https://www.wolfssl.com/documentation/manuals/wolfssl/chapter09.html
-unsafe impl Send for WolfsslPointer {}
-
 /// Wraps a `WOLFSSL` pointer, as well as the additional fields needed to
 /// write into, and read from, wolfSSL's custom IO callbacks.
 pub struct Session<IOCB: IOCallbacks> {
@@ -216,18 +191,12 @@ impl<IOCB: IOCallbacks> Session<IOCB> {
     /// Invokes [`wolfSSL_new`][0]
     ///
     /// [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__Setup.html#function-wolfssl_new
-    pub fn new_from_context(
-        ctx: &Context,
+    pub(crate) fn new_from_wolfssl_pointer(
+        ssl: WolfsslPointer,
         config: SessionConfig<IOCB>,
     ) -> std::result::Result<Self, NewSessionError> {
-        // SAFETY: [`wolfSSL_new`][0] ([also][1]) needs a valid `wolfssl_sys::WOLFSSL_CTX` pointer as per documentation
-        //
-        // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__Setup.html#function-wolfssl_new
-        // [1]: https://www.wolfssl.com/doxygen/group__Setup.html#gaa37dc22775da8f6a3b5c149d5dfd6e1c
-        let ptr = unsafe { wolfssl_sys::wolfSSL_new(ctx.ctx().as_ptr()) };
-
         let mut session = Self {
-            ssl: WolfsslPointer(NonNull::new(ptr).ok_or(NewSessionError::CreateFailed)?),
+            ssl,
             io: Box::new(config.io),
             #[cfg(feature = "debug")]
             secret_cb: Default::default(),


### PR DESCRIPTION
This adds `unsafe_op_in_unsafe_fn` and `unused_unsafe` from rustc plus `multiple_unsafe_ops_per_block`, `undocumented_unsafe_blocks` and `unnecessary_safety_comment` to the wolfssl crate.

This forces us to be more robust in our safety comments, in particular `unsafe_op_in_unsafe_fn` and `multiple_unsafe_ops_per_block` are good practice to ensure that every unsafe operation has a corresponding safety comment.