### PR TITLE
wolfssl: patch out unused falcon and dilithium

### DIFF
--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -19,7 +19,7 @@ build-target = "0.4.0"
 [dependencies.oqs-sys]
 version = "0.9.1"
 default-features = false
-features = ["kyber", "dilithium", "falcon"]
+features = ["kyber"]
 optional = true
 
 [features]

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -43,7 +43,7 @@ fn copy_wolfssl(dest: &Path) -> std::io::Result<PathBuf> {
 }
 
 const PATCH_DIR: &str = "patches";
-const PATCHES: &[&str] = &[];
+const PATCHES: &[&str] = &["disable-falcon-dilithium.patch"];
 
 /**
  * Apply patch to wolfssl-src

--- a/wolfssl-sys/patches/disable-falcon-dilithium.patch
+++ b/wolfssl-sys/patches/disable-falcon-dilithium.patch
@@ -1,0 +1,15 @@
+diff --git a/wolfssl/wolfcrypt/settings.h b/wolfssl/wolfcrypt/settings.h
+index 5eacd6c87..ab8632744 100644
+--- a/wolfssl/wolfcrypt/settings.h
++++ b/wolfssl/wolfcrypt/settings.h
+@@ -3070,8 +3070,8 @@ extern void uITRON4_free(void *p) ;
+  * group */
+ #ifdef HAVE_LIBOQS
+ #define HAVE_PQC
+-#define HAVE_FALCON
+-#define HAVE_DILITHIUM
++// #define HAVE_FALCON
++// #define HAVE_DILITHIUM
+ #ifndef WOLFSSL_NO_SPHINCS
+     #define HAVE_SPHINCS
+ #endif


### PR DESCRIPTION
We disable falcon and dilithium as we are currently not using either of these schemes. This reduces the size of our library significantly.