### PR TITLE
Update to wolfssl 5.7.2

### DIFF
--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -49,16 +49,21 @@ const PATCHES: &[&str] = &["disable-falcon-dilithium.patch"];
  * Apply patch to wolfssl-src
  */
 fn apply_patch(wolfssl_path: &Path, patch: impl AsRef<Path>) {
-    let patch = Path::new(PATCH_DIR).join(patch);
+    let full_patch = Path::new(PATCH_DIR).join(patch.as_ref());
 
-    let patch_buffer = File::open(patch).unwrap();
-    Command::new("patch")
+    let patch_buffer = File::open(full_patch).unwrap();
+    let status = Command::new("patch")
         .arg("-d")
         .arg(wolfssl_path)
         .arg("-p1")
         .stdin(patch_buffer)
         .status()
         .unwrap();
+    assert!(
+        status.success(),
+        "Failed to apply {}",
+        patch.as_ref().display()
+    );
 }
 
 /**

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -51,6 +51,8 @@ const PATCHES: &[&str] = &["disable-falcon-dilithium.patch"];
 fn apply_patch(wolfssl_path: &Path, patch: impl AsRef<Path>) {
     let full_patch = Path::new(PATCH_DIR).join(patch.as_ref());
 
+    println!("cargo:rerun-if-changed={}", full_patch.display());
+
     let patch_buffer = File::open(full_patch).unwrap();
     let status = Command::new("patch")
         .arg("-d")

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -118,6 +118,8 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
         .enable("supportedcurves", None)
         // Enable TLS/1.3
         .enable("tls13", None)
+        // Enable liboqs, etc
+        .enable("experimental", None)
         // CFLAGS
         .cflag("-g")
         .cflag("-fPIC")

--- a/wolfssl-sys/patches/disable-falcon-dilithium.patch
+++ b/wolfssl-sys/patches/disable-falcon-dilithium.patch
@@ -1,15 +1,32 @@
+diff --git a/wolfssl/internal.h b/wolfssl/internal.h
+index 390b21b54..98458c780 100644
+--- a/wolfssl/internal.h
++++ b/wolfssl/internal.h
+@@ -3429,7 +3429,7 @@ typedef struct KeyShareEntry {
+     word32                keyLen;    /* Key size (bytes)                  */
+     byte*                 pubKey;    /* Public key                        */
+     word32                pubKeyLen; /* Public key length                 */
+-#if !defined(NO_DH) || defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
++#if !defined(NO_DH) || defined(HAVE_PQC)
+     byte*                 privKey;   /* Private key - DH and PQ KEMs only */
+     word32                privKeyLen;/* Only for PQ KEMs. */
+ #endif
 diff --git a/wolfssl/wolfcrypt/settings.h b/wolfssl/wolfcrypt/settings.h
-index 5eacd6c87..ab8632744 100644
+index a4302c700..f1ddb2231 100644
 --- a/wolfssl/wolfcrypt/settings.h
 +++ b/wolfssl/wolfcrypt/settings.h
-@@ -3070,8 +3070,8 @@ extern void uITRON4_free(void *p) ;
+@@ -3351,10 +3351,10 @@ extern void uITRON4_free(void *p) ;
   * group */
  #ifdef HAVE_LIBOQS
  #define HAVE_PQC
 -#define HAVE_FALCON
--#define HAVE_DILITHIUM
+-#ifndef HAVE_DILITHIUM
+-    #define HAVE_DILITHIUM
+-#endif
 +// #define HAVE_FALCON
-+// #define HAVE_DILITHIUM
++// #ifndef HAVE_DILITHIUM
++//     #define HAVE_DILITHIUM
++// #endif
  #ifndef WOLFSSL_NO_SPHINCS
      #define HAVE_SPHINCS
  #endif


### PR DESCRIPTION
Moving from v5.6.6-stable we are picking up:
* https://github.com/wolfSSL/wolfssl/releases/tag/v5.7.0-stable
* https://github.com/wolfSSL/wolfssl/releases/tag/v5.7.2-stable
(there was no 5.7.1)
    
Our `disable-falcon-dilithium.patch` required an update, likely due to the changes in https://github.com/wolfSSL/wolfssl/pull/7622.
