### PR TITLE
Address new clippy lint in Rust 1.83

### DIFF
--- a/wolfssl/tests/ping_pong.rs
+++ b/wolfssl/tests/ping_pong.rs
@@ -1,3 +1,5 @@
+//! Test sending ping/pong messages back and forth
+
 #![deny(unsafe_code)] // unsafety should all be in the library.
 
 #[cfg(feature = "debug")]


### PR DESCRIPTION
```
error: missing documentation for the crate
   --> wolfssl/tests/ping_pong.rs:1:1
    |
1   | / #![deny(unsafe_code)] // unsafety should all be in the library.
2   | |
3   | | #[cfg(feature = "debug")]
4   | | use wolfssl::Tls13SecretCallbacks;
...   |
268 | |     tokio::join!(client, server);
269 | | }
    | |_^
    |
    = note: requested on the command line with `-D missing-docs`
```

---

https://github.com/expressvpn/wolfssl-rs/pull/198 is waiting for https://github.com/docker-library/official-images/pull/17990 so CI will pass. In the meantime address the new lints discovered by running locally.
