### PR TITLE
Fix cargo deny CI failure

### DIFF
--- a/.github/workflows/nightly-cargo-deny.yaml
+++ b/.github/workflows/nightly-cargo-deny.yaml
@@ -11,4 +11,4 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: EmbarkStudios/cargo-deny-action@v2


### PR DESCRIPTION
Cargo deny CI started throwing errors recently after rust 1.83.0 upgrade:

https://github.com/expressvpn/wolfssl-rs/actions/runs/12139835174/job/33848300194

Error:
```
2024-12-03 12:39:37 [ERROR] failed to fetch crates: warning: /github/workspace/wolfssl/Cargo.toml: unused manifest key `lints` (may be supported in a future version)

this Cargo does not support nightly features, but if you
switch to nightly channel you can pass
`-Zlints` to enable this feature.
error: failed to parse lock file at: /github/workspace/Cargo.lock
2024-12-03 12:39:37 [ERROR] failed to fetch crates: warning: /github/workspace/wolfssl/Cargo.toml: unused manifest key `lints` (may be supported in a future version)
```

Updated the github action version which has the fix for rust 1.83.0: 
https://github.com/EmbarkStudios/cargo-deny-action/releases/tag/v2.0.4