### PR TITLE
CVPN-1846 Build WolfSSL on iOS/tvOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,3 +148,17 @@ jobs:
       - name: Coverage check fails
         if: steps.coverage-check.outputs.failed == 'true'
         run: exit 1
+  build-ios-tvos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install automake
+        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
+      - name: Fetch WolfSSL
+        run: git submodule update --init
+      - name: Install all platform targets
+        run: rustup target add aarch64-apple-ios aarch64-apple-ios-sim
+      - name: Build on iOS
+        run: IPHONEOS_DEPLOYMENT_TARGET=15.0 cargo build --release --target aarch64-apple-ios -v -v
+      - name: Build on iOS Sim
+        run: IPHONEOS_DEPLOYMENT_TARGET=15.0 cargo build --release --target aarch64-apple-ios-sim -v -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress:  ${{ github.ref_name != 'main' }}
 
+env:
+  RUST_VERSION: 1.85.0
+
 jobs:
   ci:
     needs: [earthly, coverage, build-ios, build-tvos]
@@ -156,6 +159,10 @@ jobs:
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Fetch WolfSSL
         run: git submodule update --init
+      - name: Update Rust version
+        run: | 
+              rustup install $RUST_VERSION
+              rustup default $RUST_VERSION
       - name: Install iOS platform targets
         run: rustup target add aarch64-apple-ios aarch64-apple-ios-sim
       - name: Build on iOS
@@ -171,11 +178,11 @@ jobs:
       - name: Fetch WolfSSL
         run: git submodule update --init
       # We would need to build the tvOS with nightly feature (-Zbuild-std) as `aarch64-apple-tvos` is a tier 3 target and does not support building host tools.
+      # Since it forces us to use nightly toolchain, we download the nightly for $RUST_VERSION on the specific archieve date from https://github.com/oxalica/rust-overlay/tree/master/manifests/nightly/2025
       - name: Setup Rust toolchain for nightly feature
         run: |
-              rustup toolchain install nightly
-              
-              rustup component add rust-src --toolchain nightly
+              rustup toolchain install nightly-2025-01-03
+              rustup component add rust-src --toolchain nightly-2025-01-03-aarch64-apple-darwin
       - name: Build on tvOS
         run: TVOS_DEPLOYMENT_TARGET=17.0 cargo +nightly-2025-01-03 build -Zbuild-std --release --target aarch64-apple-tvos -v -v
       - name: Build on tvOS Sim

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   ci:
-    needs: [earthly, coverage]
+    needs: [earthly, coverage, build-ios, build-tvos]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -148,7 +148,7 @@ jobs:
       - name: Coverage check fails
         if: steps.coverage-check.outputs.failed == 'true'
         run: exit 1
-  build-ios-tvos:
+  build-ios:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -156,9 +156,28 @@ jobs:
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Fetch WolfSSL
         run: git submodule update --init
-      - name: Install all platform targets
+      - name: Install iOS platform targets
         run: rustup target add aarch64-apple-ios aarch64-apple-ios-sim
       - name: Build on iOS
         run: IPHONEOS_DEPLOYMENT_TARGET=15.0 cargo build --release --target aarch64-apple-ios -v -v
       - name: Build on iOS Sim
         run: IPHONEOS_DEPLOYMENT_TARGET=15.0 cargo build --release --target aarch64-apple-ios-sim -v -v
+  build-tvos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install automake
+        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
+      - name: Fetch WolfSSL
+        run: git submodule update --init
+      # We would need to build the tvOS with nightly feature (-Zbuild-std) as `aarch64-apple-tvos` is a tier 3 target and does not support building host tools.
+      - name: Setup Rust toolchain for nightly feature
+        run: |
+              rustup toolchain install nightly
+              
+              rustup component add rust-src --toolchain nightly
+      - name: Build on tvOS
+        run: TVOS_DEPLOYMENT_TARGET=17.0 cargo +nightly-2025-01-03 build -Zbuild-std --release --target aarch64-apple-tvos -v -v
+      - name: Build on tvOS Sim
+        run: TVOS_DEPLOYMENT_TARGET=17.0 cargo +nightly-2025-01-03 build -Zbuild-std --release --target aarch64-apple-tvos-sim -v -v
+

--- a/Earthfile
+++ b/Earthfile
@@ -2,6 +2,7 @@ VERSION 0.8
 # Importing https://github.com/earthly/lib/tree/3.0.1/rust via commit hash pinning because git tags can be changed
 IMPORT github.com/earthly/lib/rust:1a4a008e271c7a5583e7bd405da8fd3624c05610 AS lib-rust
 
+# Update RUST_VERSION in github action to the same version for building iOS/tvOS
 FROM rust:1.85.0
 
 WORKDIR /wolfssl-rs

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -226,6 +226,31 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
         conf.env("LIBS", "-llog -landroid");
     }
 
+    if build_target::target_os().unwrap() == build_target::Os::iOs {
+        // Check whether we have set IPHONEOS_DEPLOYMENT_TARGET to ensure we support older iOS
+        let ios_target = env::var("IPHONEOS_DEPLOYMENT_TARGET")
+            .expect("Must have set minimum supported iOS version");
+        if ios_target.is_empty() {
+            panic!("IPHONEOS_DEPLOYMENT_TARGET is empty")
+        }
+
+        // Build options for iOS
+        let (chost, arch_flags, arch) = match build_target::target_arch().unwrap() {
+            build_target::Arch::AARCH64 => ("arm64-apple-ios", "-O3", "arm64"),
+            _ => panic!("Unsupported build_target for iOS"),
+        };
+
+        // Per arch configurations
+        conf.config_option("host", Some(chost));
+        conf.cflag(arch_flags);
+        conf.cxxflag(arch_flags);
+        conf.env("ARCH", arch);
+
+        // General iOS specific configurations
+        conf.disable("crypttests", None);
+        conf.cflag("-D_FORTIFY_SOURCE=2");
+    }
+
     // Build and return the config
     conf.build()
 }

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -251,6 +251,31 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
         conf.cflag("-D_FORTIFY_SOURCE=2");
     }
 
+    if build_target::target_os().unwrap() == build_target::Os::from_str("tvos") {
+        // Check whether we have set TVOS_DEPLOYMENT_TARGET to ensure we support older tvOS
+        let ios_target = env::var("TVOS_DEPLOYMENT_TARGET")
+            .expect("Must have set minimum supported tvOS version");
+        if ios_target.is_empty() {
+            panic!("TVOS_DEPLOYMENT_TARGET is empty")
+        }
+
+        // Build options for tvos
+        let (chost, arch_flags, arch) = match build_target::target_arch().unwrap() {
+            build_target::Arch::AARCH64 => ("arm64-apple-ios", "-O3", "arm64"),
+            _ => panic!("Unsupported build_target for tvos"),
+        };
+
+        // Per arch configurations
+        conf.config_option("host", Some(chost));
+        conf.cflag(arch_flags);
+        conf.cxxflag(arch_flags);
+        conf.env("ARCH", arch);
+
+        // General iOS specific configurations
+        conf.disable("crypttests", None);
+        conf.cflag("-D_FORTIFY_SOURCE=2");
+    }
+
     // Build and return the config
     conf.build()
 }


### PR DESCRIPTION
Build WolfSSL on the iOS/tvOS platform with similar build flags from lightway-core. We would need to set `TVOS_DEPLOYMENT_TARGET` or `IPHONEOS_DEPLOYMENT_TARGET` in the environment variable as well in the cargo config, as it is needed to make sure we support older iOS version as well

We would need to build the tvOS with nightly feature (-Zbuild-std) as `aarch64-apple-tvos` is a tier 3 target and does not support building host tools.

Build flag for iOS:
```
[wolfssl-sys 2.0.0]    * System type:                apple-ios
[wolfssl-sys 2.0.0]    * Host CPU:                   aarch64
[wolfssl-sys 2.0.0]    * C Compiler:                 clang
[wolfssl-sys 2.0.0]    * C Flags:                    -O3 -fPIC --target=arm64-apple-ios -miphoneos-version-min=15.0 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk  -g -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256 -DWOLFSSL_NO_SPHINCS -DWOLFSSL_TLS13_MIDDLEBOX_COMPAT -O3 -D_FORTIFY_SOURCE=2   -Wno-pragmas -Wall -Wextra -Wunknown-pragmas -Waddress -Warray-bounds -Wbad-function-cast -Wchar-subscripts -Wcomment -Wfloat-equal -Wformat-security -Wformat=2 -Wmissing-field-initializers -Wmissing-noreturn -Wmissing-prototypes -Wnested-externs -Woverride-init -Wpointer-arith -Wpointer-sign -Wshadow -Wshorten-64-to-32 -Wsign-compare -Wstrict-overflow=1 -Wstrict-prototypes -Wswitch-enum -Wundef -Wunused -Wunused-result -Wunused-variable -Wwrite-strings -fwrapv
[wolfssl-sys 2.0.0]    * C++ Compiler:               clang++
[wolfssl-sys 2.0.0]    * C++ Flags:                  -O3 -fPIC --target=arm64-apple-ios -miphoneos-version-min=15.0 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk  -O3
[wolfssl-sys 2.0.0]    * CPP Flags:                  
[wolfssl-sys 2.0.0]    * CCAS Flags:                 -O3 -fPIC --target=arm64-apple-ios -miphoneos-version-min=15.0 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk  -g -fPIC -DWOLFSSL_DTLS_ALLOW_FUTURE -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DUSE_CERT_BUFFERS_4096 -DUSE_CERT_BUFFERS_256 -DWOLFSSL_NO_SPHINCS -DWOLFSSL_TLS13_MIDDLEBOX_COMPAT -O3 -D_FORTIFY_SOURCE=2  
```

From lightway-core:
```
   * Installation prefix:        /Users/runner/work/lightway-core/lightway-core/third_party/wolfssl/../builds/wolfssl_ios
   * System type:                apple-ios
   * Host CPU:                   aarch64
   * C Compiler:                 /Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
   * C Flags:                    -arch arm64 -miphoneos-version-min=12.0 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk -O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DWOLFSSL_NO_SPHINCS -DWOLFSSL_TLS13_MIDDLEBOX_COMPAT  -Werror -Wno-pragmas -Wall -Wextra -Wunknown-pragmas --param=ssp-buffer-size=1 -Waddress -Warray-bounds -Wbad-function-cast -Wchar-subscripts -Wcomment -Wfloat-equal -Wformat-security -Wformat=2 -Wmissing-field-initializers -Wmissing-noreturn -Wmissing-prototypes -Wnested-externs -Woverride-init -Wpointer-arith -Wpointer-sign -Wshadow -Wshorten-64-to-32 -Wsign-compare -Wstrict-overflow=1 -Wstrict-prototypes -Wswitch-enum -Wundef -Wunused -Wunused-result -Wunused-variable -Wwrite-strings -fwrapv
   * C++ Compiler:               /Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++
   * C++ Flags:                  -arch arm64 -miphoneos-version-min=12.0 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk -O3
   * CPP Flags:                  
   * CCAS Flags:                 -arch arm64 -miphoneos-version-min=12.0 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk -O3 -fPIC -D_FORTIFY_SOURCE=2 -DWOLFSSL_MIN_RSA_BITS=2048 -DWOLFSSL_MIN_ECC_BITS=256 -DWOLFSSL_NO_SPHINCS -DWOLFSSL_TLS13_MIDDLEBOX_COMPAT 
   * LD Flags:                   -arch arm64 -miphoneos-version-min=12.0 -isysroot /Applications/Xcode_15.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS17.5.sdk
```