### PR TITLE
ci: checkout submodules to save time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,10 +158,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+            submodules: true
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
-      - name: Fetch WolfSSL
-        run: git submodule update --init
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -177,10 +177,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+            submodules: true
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
-      - name: Fetch WolfSSL
-        run: git submodule update --init
       # We would need to build the tvOS with nightly feature (-Zbuild-std) as `aarch64-apple-tvos` is a tier 3 target and does not support building host tools.
       # Since it forces us to use nightly toolchain, we download the nightly for $RUST_VERSION on the specific archieve date from https://github.com/oxalica/rust-overlay/tree/master/manifests/nightly/2025
       - name: Setup Rust toolchain


### PR DESCRIPTION
Checkout submodules as well when we are using github action's checkout to save time fetching from WolfSSL's repo.

Reference: https://github.com/marketplace/actions/checkout