### PR TITLE
ci: auto update Rust version in GitHub action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ concurrency:
 
 env:
   RUST_VERSION: 1.85.1
+  # We pin to a specific nightly Rust version (the one that eventually became $RUST_VERSION)
+  # to ensure consistent behavior and prevent unexpected changes.
+  # Reference: https://releases.rs/ (Use the branched from master date on the specific release)
   RUST_NIGHTLY_VERSION: nightly-2025-01-03
 
 jobs:
@@ -181,8 +184,6 @@ jobs:
             submodules: true
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
-      # We would need to build the tvOS with nightly feature (-Zbuild-std) as `aarch64-apple-tvos` is a tier 3 target and does not support building host tools.
-      # Since it forces us to use nightly toolchain, we download the nightly for $RUST_VERSION on the specific archieve date from https://github.com/oxalica/rust-overlay/tree/master/manifests/nightly/2025
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/nightly-rust-update-check.yaml
+++ b/.github/workflows/nightly-rust-update-check.yaml
@@ -33,6 +33,9 @@ jobs:
     - name: Update Rust version in Earthfile
       run: sed -i -E 's/^(\s*FROM rust):(:?[0-9\.]+)$/\1:${{ steps.check-version.outputs.rust }}/g' Earthfile
 
+    - name: Update Rust version in Github action
+      run: sed -i -E 's/^(\s*RUST_VERSION:\s*)([0-9\.]+)$/\1${{ steps.check-version.outputs.rust }}/g' .github/workflows/ci.yaml
+
     - uses: peter-evans/create-pull-request@v6
       with:
         token: ${{ secrets.SERVICE_ACCOUNT_PAT }}


### PR DESCRIPTION
Update GitHub bot to auto-update RUST_VERSION in github action as well to be in-sync with Earthfile