### PR TITLE
Add new error variant PeerClosed

### DIFF
--- a/wolfssl-sys/src/bindings.rs
+++ b/wolfssl-sys/src/bindings.rs
@@ -18,6 +18,7 @@ pub const WOLFSSL_ERROR_WANT_READ_c_int: c_int = WOLFSSL_ERROR_WANT_READ as c_in
 pub const WOLFSSL_ERROR_WANT_WRITE_c_int: c_int = WOLFSSL_ERROR_WANT_WRITE as c_int;
 pub const WOLFSSL_SHUTDOWN_NOT_DONE_c_int: c_int = WOLFSSL_SHUTDOWN_NOT_DONE as c_int;
 pub const WOLFSSL_ERROR_NONE_c_int: c_int = WOLFSSL_ERROR_NONE as c_int;
+pub const WOLFSSL_ERROR_ZERO_RETURN_c_int: c_int = WOLFSSL_ERROR_ZERO_RETURN as c_int;
 pub const WOLFSSL_VERIFY_NONE_c_int: c_int = WOLFSSL_VERIFY_NONE as c_int;
 pub const WOLFSSL_VERIFY_PEER_c_int: c_int = WOLFSSL_VERIFY_PEER as c_int;
 pub const WOLFSSL_VERIFY_FAIL_IF_NO_PEER_CERT_c_int: c_int =

--- a/wolfssl/src/error.rs
+++ b/wolfssl/src/error.rs
@@ -4,6 +4,8 @@ use bytes::Bytes;
 use thiserror::Error;
 use wolfssl_sys::wolfSSL_ErrorCodes_DOMAIN_NAME_MISMATCH as WOLFSSL_ERROR_DOMAIN_NAME_MISMATCH;
 use wolfssl_sys::wolfSSL_ErrorCodes_DUPLICATE_MSG_E as WOLFSSL_ERROR_DUPLICATE_MSG_E;
+use wolfssl_sys::wolfSSL_ErrorCodes_ZERO_RETURN as WOLFSSL_ERROR_ZERO_RETURN_ALT;
+use wolfssl_sys::WOLFSSL_ERROR_ZERO_RETURN_c_int as WOLFSSL_ERROR_ZERO_RETURN;
 
 /// The `Result::Ok` for a non-blocking operation.
 #[derive(Debug)]
@@ -61,6 +63,9 @@ pub enum ErrorKind {
     /// Duplicate message error
     #[error("Duplicate message error")]
     DuplicateMessage,
+    /// Peer sent close notify alert
+    #[error("Peer sent close notify alert")]
+    PeerClosed,
     /// All other wolfssl fatal errors
     #[error("code: {code}, what: {what}")]
     Other {
@@ -79,6 +84,8 @@ impl std::convert::From<c_int> for ErrorKind {
         let this = match code {
             WOLFSSL_ERROR_DOMAIN_NAME_MISMATCH => Self::DomainNameMismatch,
             WOLFSSL_ERROR_DUPLICATE_MSG_E => Self::DuplicateMessage,
+            WOLFSSL_ERROR_ZERO_RETURN => Self::PeerClosed,
+            WOLFSSL_ERROR_ZERO_RETURN_ALT => Self::PeerClosed,
             _other => Self::Other {
                 what: wolf_error_string(code as std::ffi::c_ulong),
                 code,


### PR DESCRIPTION
Add new error variant PeerClosed when the peer sends close notify alert.

WolfSsl uses two errors for same error (ref below), just follow the same.

Ref:
https://github.com/wolfSSL/wolfssl/blob/c29fba5b7ed912bb62e6bc6bd2e87562fd16ad3e/src/internal.c#L26439-L26441
