### PR TITLE
wolfssl: "INIT_MP_INT_SIZE failed" fix on ARM32

### DIFF
--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -169,6 +169,11 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
             if build_target::target_os().unwrap() != build_target::Os::Android {
                 conf.enable("armasm", None);
             }
+
+            // This is needed to support 4096 bits keys
+            // Otherwise, INIT_MP_INT_SIZE failed error happens
+            // Reference: https://www.wolfssl.com/documentation/manuals/wolfssl/chapter02.html#sp_int_bits
+            conf.cflag("-DSP_INT_BITS=4096");
         }
         build_target::Arch::X86 => {
             // Disable sp asm optmisations which has been enabled earlier


### PR DESCRIPTION
According to the docs, the marco "SP_INT_BITS" determines the number of bits in sp_int, which is the largest bignum that can be handled. https://www.wolfssl.com/documentation/manuals/wolfssl/chapter02.html#sp_int_bits

By default it is 3072. Since we are using 4096 bits keys, we need to add the c flag "-DSP_INT_BITS=4096" override the marco and support 4096 bits keys.