### PR TITLE
CVPN-2060: Fix 4096 bits keys failing on RISC-V64

### DIFF
--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -195,6 +195,8 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
             conf.disable("sp-asm", None);
             // Stop frame pointer s0 in RISC-V from being contested
             conf.cflag("-fomit-frame-pointer");
+            // Fix INIT_MP_INT_SIZE failed errors
+            conf.cflag("-DSP_INT_BITS=4096");
         }
         _ => {}
     }

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -119,8 +119,9 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
         .enable("singlethreaded", None)
         // Enable SNI
         .enable("sni", None)
-        // Enable single precision
-        .enable("sp", None)
+        // Enable single precision 4096 bits RSA/DH support
+        // https://www.wolfssl.com/documentation/manuals/wolfssl/chapter02.html#-enable-spopt
+        .enable("sp", Some("yes,4096"))
         // Enable single precision ASM
         .enable("sp-asm", None)
         // Only build the static library
@@ -169,11 +170,6 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
             if build_target::target_os().unwrap() != build_target::Os::Android {
                 conf.enable("armasm", None);
             }
-
-            // This is needed to support 4096 bits keys
-            // Otherwise, INIT_MP_INT_SIZE failed error happens
-            // Reference: https://www.wolfssl.com/documentation/manuals/wolfssl/chapter02.html#sp_int_bits
-            conf.cflag("-DSP_INT_BITS=4096");
         }
         build_target::Arch::X86 => {
             // Disable sp asm optmisations which has been enabled earlier
@@ -195,8 +191,6 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
             conf.disable("sp-asm", None);
             // Stop frame pointer s0 in RISC-V from being contested
             conf.cflag("-fomit-frame-pointer");
-            // Fix INIT_MP_INT_SIZE failed errors
-            conf.cflag("-DSP_INT_BITS=4096");
         }
         _ => {}
     }


### PR DESCRIPTION
# Description
This fixes `INIT_MP_INT_SIZE` errors on `riscv64gc`.
The fix for `INIT_MP_INT_SIZE` can be refactored with #260 in ARM32, into `enable-sp=yes,4096`.
The flag is already present on `lightway-core`, but we missed the flag here, so we are adding it back here.

# Testing
Manually tested on real `riscv64gc` device and connected to server successfully using a 4096 bits key.
Tested with `cargo test` and the tests pass.