### PR TITLE
CVPN-2123 Add Feature `system-ca-certs`

### DIFF
--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -24,6 +24,7 @@ default = ["postquantum"]
 debug = []
 postquantum = []
 kyber_only = ["postquantum"]
+system_ca_certs = []
 
 [[example]]
 name = "connect_pq"

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -157,6 +157,10 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
             .enable("sha3", None);
     }
 
+    if cfg!(feature = "system_ca_certs") {
+        conf.enable("sys-ca-certs", None);
+    }
+
     match build_target::target_arch().unwrap() {
         build_target::Arch::AArch64 => {
             // Enable ARM ASM optimisations

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -13,6 +13,7 @@ default = ["postquantum"]
 postquantum = ["wolfssl-sys/postquantum"]
 debug = ["wolfssl-sys/debug"] # Note that application code must also call wolfssl::enable_debugging(true)
 kyber_only = ["wolfssl-sys/kyber_only"]
+system_ca_certs = ["wolfssl-sys/system_ca_certs"]
 
 [lints.rust]
 missing_docs = "deny"

--- a/wolfssl/src/context.rs
+++ b/wolfssl/src/context.rs
@@ -422,6 +422,17 @@ impl ContextBuilder {
         self
     }
 
+    /// Wraps `wolfSSL_CTX_load_system_CA_certs`[0]([also][1])
+    // [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__CertsKeys.html#function-wolfssl_ctx_load_system_ca_certs
+    // [1]: https://www.wolfssl.com/doxygen/group__CertsKeys.html#gaa66006fab6369002eda43cb4f83c857d
+    #[cfg(feature = "system_ca_certs")]
+    pub fn with_system_ca_certs(self) -> Self {
+        // SAFETY: [`wolfSSL_CTX_load_system_CA_certs`][0] ([also][1]) requires a valid `ctx` pointer
+        // from `wolfSSL_CTX_new()`.
+        unsafe { wolfssl_sys::wolfSSL_CTX_load_system_CA_certs(self.ctx.as_ptr()) };
+        self
+    }
+
     /// Finalizes a `WolfContext`.
     pub fn build(self) -> Context {
         Context {


### PR DESCRIPTION
Add an optional feature where wolfssl will be compiled with enable-sys-ca-certs such that it can load trusted certificates from the system's trust store.

Even with this feature on, unless the wolfssl context has called wolfSSL_CTX_load_system_CA_certs, the system's certs will not be loaded.