### PR TITLE
ca-cert: Compile library with WOLFSSL_APPLE_NATIVE_CERT_VALIDATION

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -157,9 +157,9 @@ jobs:
           toolchain: $RUST_VERSION
           target: aarch64-apple-ios, aarch64-apple-ios-sim, x86_64-apple-ios
       - name: Build on iOS
-        run: cargo build --release --target aarch64-apple-ios -v -v
+        run: cargo build --release --target aarch64-apple-ios --features system_ca_certs -v -v
       - name: Build on iOS Sim
-        run: cargo build --release --target aarch64-apple-ios-sim --target x86_64-apple-ios -v -v
+        run: cargo build --release --target aarch64-apple-ios-sim --target x86_64-apple-ios --features system_ca_certs -v -v
   build-tvos:
     env:
       TVOS_DEPLOYMENT_TARGET: '17.0'
@@ -176,6 +176,6 @@ jobs:
           toolchain: $RUST_NIGHTLY_VERSION
           components: rust-src
       - name: Build on tvOS
-        run: cargo +$RUST_NIGHTLY_VERSION build -Zbuild-std --release --target aarch64-apple-tvos -v -v
+        run: cargo +$RUST_NIGHTLY_VERSION build -Zbuild-std --release --target aarch64-apple-tvos --features system_ca_certs -v -v
       - name: Build on tvOS Sim
-        run: cargo +$RUST_NIGHTLY_VERSION build -Zbuild-std --release --target aarch64-apple-tvos-sim --target x86_64-apple-tvos -v -v
+        run: cargo +$RUST_NIGHTLY_VERSION build -Zbuild-std --release --target aarch64-apple-tvos-sim --target x86_64-apple-tvos --features system_ca_certs -v -v

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -264,9 +264,12 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
         // General iOS specific configurations
         conf.disable("crypttests", None);
         conf.cflag("-D_FORTIFY_SOURCE=2");
+        if cfg!(feature = "system_ca_certs") {
+            conf.cflag("-DWOLFSSL_APPLE_NATIVE_CERT_VALIDATION");
+        }
     }
 
-    if build_target::target_os().unwrap() == build_target::Os::from_str("tvos") {
+    if build_target::target_os().unwrap() == build_target::Os::TvOS {
         // Check whether we have set TVOS_DEPLOYMENT_TARGET to ensure we support older tvOS
         let ios_target = env::var("TVOS_DEPLOYMENT_TARGET")
             .expect("Must have set minimum supported tvOS version");
@@ -290,6 +293,9 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
         // General tvOS specific configurations
         conf.disable("crypttests", None);
         conf.cflag("-D_FORTIFY_SOURCE=2");
+        if cfg!(feature = "system_ca_certs") {
+            conf.cflag("-DWOLFSSL_APPLE_NATIVE_CERT_VALIDATION");
+        }
     }
 
     // Build and return the config


### PR DESCRIPTION
Compile with WOLFSSL_APPLE_NATIVE_CERT_VALIDATION when system_ca_certs feature is on: https://www.wolfssl.com/wolfssl-extends-support-for-system-ca-certificates-to-apple-devices/