### PR TITLE
Fix release CI failing from forked repos

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,11 +27,19 @@ jobs:
           state: all
       - id: pr_labels
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr }}
+          EVENT_NUMBER: ${{ github.event.number }}
         with:
           script: |
-            const issue_number = ${{ steps.find_pr.outputs.pr }}
             const owner = context.repo.owner
             const repo = context.repo.repo
+            const issue_number = context.eventName === 'pull_request' ? process.env.EVENT_NUMBER : process.env.PR_NUMBER
+
+            if (!owner || !repo || !issue_number) {
+              core.setFailed(`Missing required parameters: owner=${owner}, repo=${repo}, issue_number=${issue_number}`)
+              return
+            }
 
             const attached_labels = (await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number })).data
 

--- a/Earthfile
+++ b/Earthfile
@@ -3,7 +3,7 @@ VERSION 0.8
 IMPORT github.com/earthly/lib/rust:1a4a008e271c7a5583e7bd405da8fd3624c05610 AS lib-rust
 
 # Update RUST_VERSION in github action to the same version for building iOS/tvOS
-FROM rust:1.89.0
+FROM rust:1.89.0-bookworm
 
 WORKDIR /wolfssl-rs
 


### PR DESCRIPTION
Until now, we use gh-find-current-pr to find the PR number of thespecified commit. This was needed when the action is triggered from main branch push event, since we do not know the PR number from context.

This also works fine for pull requests from branches created in main repo. But it is failing for forked repos.

Example (logs may be purged in future):
https://github.com/expressvpn/wolfssl-rs/actions/runs/16980030164/job/48137907811


To overcome this issue, use `github.event.number` for pull request event and use the one from above action if it is push event.