### PR TITLE
wolfssl-sys: fix skip copying .git dir while building

### DIFF
--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -121,10 +121,10 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
         let src_path = entry.path();
         let dest_path = dest.join(entry.file_name());
 
-        if src_path.is_dir() {
-            copy_dir_recursive(&src_path, &dest_path)?
-        } else if entry.file_name() == ".git" {
+        if entry.file_name() == ".git" {
             // Skip copying .git
+        } else if src_path.is_dir() {
+            copy_dir_recursive(&src_path, &dest_path)?
         } else {
             fs::copy(&src_path, &dest_path).inspect_err(|e| {
                 println!(


### PR DESCRIPTION
Previously we skipped copying the .git directory/file in this commit:
   https://github.com/expressvpn/wolfssl-rs/pull/286/commits/ead8c149be04cfb3da1f79e6fc9aab9c230a706d

   to allow git patch in windows.

   When testing in local environment, wolfssl-src is a submodule,
   so `.git` will be a file and this works fine with recompilation.
   But while building as a dependency (ex: lightway), wolfssl-src will be a directory.

   And this breaks CI, since `if check` order is wrong and .git
   directory is being copied unintentionally to the build folder
   throwing the following error:

    ```
    [wolfssl-sys 2.0.0] cargo:rerun-if-changed=wolfssl-src
    [wolfssl-sys 2.0.0] Error: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
    [wolfssl-sys 2.0.0] Error while copying dir "wolfssl-src/.git/objects/pack/pack-c1c40017c4f9c4d57bd3f9e434a4dd1a56d02c9b.rev": "/work/github/expressvpn/lightway/target/release/build/wolfssl-sys-281f4dc12824204f/out/wolfssl-src/.git/objects/pack/pack-c1c40017c4f9c4d57bd3f9e434a4dd1a56d02c9b.rev"
    ```

   Permission denied error is because the objects inside the .git folder
   are readonly and does not allow to copy again:

    ```
    ❯ ls -l .git/objects/pack/
    .r--r--r-- maari users 4.9 MB Mon Sep  8 17:49:48 2025  pack-c1c40017c4f9c4d57bd3f9e434a4dd1a56d02c9b.idx
    .r--r--r-- maari users 742 MB Mon Sep  8 17:49:48 2025  pack-c1c40017c4f9c4d57bd3f9e434a4dd1a56d02c9b.pack
    .r--r--r-- maari users 720 KB Mon Sep  8 17:49:47 2025  pack-c1c40017c4f9c4d57bd3f9e434a4dd1a56d02c9b.rev
    ```

   To avoid this, move the .git if check to the top which should catch
   both file and directory