### PR TITLE
debug: add install_logging_callback for safe Rust callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "wolfssl"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl"
-version = "6.0.0"
+version = "7.0.0"
 description = "High-level bindings for WolfSSL"
 authors.workspace = true
 license.workspace = true

--- a/wolfssl/src/debug.rs
+++ b/wolfssl/src/debug.rs
@@ -1,9 +1,11 @@
 #![cfg(feature = "debug")]
+#![allow(unsafe_code)]
 
+use std::ffi::{c_char, CStr};
 use std::fmt::{self, Display};
 #[allow(unused_imports)] // Needed for windows
 use std::os::raw::{c_int, c_uint};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// Application provided callbacks to receive TLS1.3 secrets
 ///
@@ -112,4 +114,37 @@ impl From<c_int> for Tls13Secret {
             e => Tls13Secret::UnknownSecret(e),
         }
     }
+}
+
+/// Application-supplied callback invoked for each wolfSSL log line
+///
+/// The callback runs on wolfSSL caller thread.
+pub type LoggingCallback = fn(message: &str);
+
+static LOGGING_CALLBACK: OnceLock<LoggingCallback> = OnceLock::new();
+
+unsafe extern "C" fn logging_trampoline(_level: c_int, msg: *const c_char) {
+    if msg.is_null() {
+        return;
+    }
+    // SAFETY: null-checked; wolfSSL emits NUL-terminated strings via snprintf.
+    let c_str = unsafe { CStr::from_ptr(msg) };
+    let message = c_str.to_str().unwrap_or("Unable to decode C string");
+
+    if let Some(cb) = LOGGING_CALLBACK.get() {
+        if std::panic::catch_unwind(|| cb(message)).is_err() {
+            log::warn!("Panic in logging callback");
+        }
+    }
+}
+
+/// Install a Rust callback to receive wolfSSL log lines
+///
+/// Also calls [`enable_debugging`](super::enable_debugging) so
+/// logging is active. Currently setting callback is a one-shot
+/// and subsequent calls silently no-op.
+pub fn install_logging_callback(cb: LoggingCallback) {
+    let _ = LOGGING_CALLBACK.set(cb);
+    super::enable_debugging(true);
+    super::set_logging_callback(Some(logging_trampoline));
 }

--- a/wolfssl/src/lib.rs
+++ b/wolfssl/src/lib.rs
@@ -100,13 +100,13 @@ pub fn enable_debugging(on: bool) {
 }
 
 #[cfg(feature = "debug")]
-pub use wolfssl_sys::wolfSSL_Logging_cb as LoggingCallback;
+pub(crate) use wolfssl_sys::wolfSSL_Logging_cb as RawLoggingCallback;
 
 /// Wraps [`wolfSSL_SetLoggingCb`][0]. You must call [`enable_debugging`] first to enable logging at runtime before setting the callback.
 ///
 /// [0]: https://www.wolfssl.com/documentation/manuals/wolfssl/group__Logging.html#function-wolfssl_setloggingcb
 #[cfg(feature = "debug")]
-pub fn set_logging_callback(cb: LoggingCallback) {
+pub(crate) fn set_logging_callback(cb: RawLoggingCallback) {
     wolf_init().expect("Unable to initialize wolfSSL");
 
     // SAFETY: [`wolfSSL_SetLoggingCb`][0] would return an error if a function pointer is not provided, or we failed to set logging callback.


### PR DESCRIPTION
The existing wolfssl::set_logging_callback exposes directly, forcing every consumer to write the FFI boilerplate  themselves (unsafe extern "C", null check, CStr conversion, UTF-8 fallback catch_unwind for panic safety). Hoist that into wolfssl-rs once.
  - Add an internal trampoline that handles the FFI translation once at                                                                                                                                                      
    the C boundary.                                                                                                                                                                                                          
  - Expose install_logging_callback(cb: fn(&str)) — registers the                                                                                                                                                            
    trampoline with wolfSSL_SetLoggingCb and stashes cb in a OnceLock                                                                                                                                                        
    for the trampoline to dispatch into.                                                                                                                                                                                     
  - Rename the existing FFI-shaped LoggingCallback alias to                                                                                                                                                                  
    RawLoggingCallback, pub(crate). The matching set_logging_callback                                                                                                                                                        
    follows — its parameter type is now opaque externally, so it's                                                                                                                                                           
    effectively crate-internal.                                                                                                                                                                                              
  - Bump wolfssl to 7.0.0 (major) for the breaking rename.  