### PR TITLE
CVPN-2575: refresh PR10492 patch with latest upstream changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "wolfssl"
-version = "7.1.0"
+version = "7.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "wolfssl-sys"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "autotools",
  "bindgen",

--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-sys"
-version = "4.1.0"
+version = "4.2.0"
 description = "System bindings for WolfSSL"
 readme = "README.md"
 authors.workspace = true

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -325,7 +325,7 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
         .cflag("-DUSE_CERT_BUFFERS_4096")
         .cflag("-DUSE_CERT_BUFFERS_256")
         .cflag("-DWOLFSSL_NO_SPHINCS")
-        .cflag("-DWOLFSSL_DTLS13_5_9_0_COMPAT")
+        .cflag("-DWOLFSSL_DTLS13_ECHO_LEGACY_SESSION_ID")
         .cflag("-DWOLFSSL_TLS13_MIDDLEBOX_COMPAT");
 
     for feature in OPTIONAL_FEATURES {

--- a/wolfssl-sys/patches/PR10492-DTLS13-backward-compatible.patch
+++ b/wolfssl-sys/patches/PR10492-DTLS13-backward-compatible.patch
@@ -1,13 +1,14 @@
-From ded6d604e05821aacccfeff6b6e6b294b0c42aba Mon Sep 17 00:00:00 2001
+From 8f477356ce843bd3228e810fd63423f3ea28ef2d Mon Sep 17 00:00:00 2001
 From: Marco Oliverio <marco@wolfssl.com>
 Date: Mon, 18 May 2026 09:30:28 +0200
-Subject: [PATCH 1/2] dtls: add compat flag for buggy pre 5.9.0 DTLSv1.3
+Subject: [PATCH 1/6] dtls: add compat flag for buggy pre 5.9.0 DTLSv1.3
  clients
 
 ---
- src/dtls.c  | 10 ++++++++--
- src/tls13.c | 15 +++++++++++----
- 2 files changed, 19 insertions(+), 6 deletions(-)
+ .wolfssl_known_macro_extras |  1 +
+ src/dtls.c                  | 10 ++++++++--
+ src/tls13.c                 | 15 +++++++++++----
+ 3 files changed, 20 insertions(+), 6 deletions(-)
 
 diff --git a/src/dtls.c b/src/dtls.c
 index b79db10330e..a22b5768bb2 100644
@@ -42,7 +43,7 @@ index b79db10330e..a22b5768bb2 100644
          nonConstSSL->options.cipherSuite = cs.cipherSuite;
          nonConstSSL->extensions = parsedExts;
 diff --git a/src/tls13.c b/src/tls13.c
-index 658b742f5ed..dc09a179bf3 100644
+index 533a03462e7..174b0d4684d 100644
 --- a/src/tls13.c
 +++ b/src/tls13.c
 @@ -5775,7 +5775,14 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
@@ -61,7 +62,7 @@ index 658b742f5ed..dc09a179bf3 100644
              WOLFSSL_MSG("args->sessIdSz != 0");
              WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
              return INVALID_PARAMETER;
-@@ -6979,7 +6986,7 @@ static int RestartHandshakeHashWithCookie(WOLFSSL* ssl, Cookie* cookie)
+@@ -6973,7 +6980,7 @@ static int RestartHandshakeHashWithCookie(WOLFSSL* ssl, Cookie* cookie)
  
      /* Reconstruct the HelloRetryMessage for handshake hash. */
      sessIdSz = ssl->session->sessionIDSz;
@@ -70,7 +71,7 @@ index 658b742f5ed..dc09a179bf3 100644
      /* RFC 9147 Section 5.3: DTLS 1.3 must use empty legacy_session_id. */
      if (ssl->options.dtls)
          sessIdSz = 0;
-@@ -7459,7 +7466,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+@@ -7453,7 +7460,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
      if (sessIdSz + args->idx > helloSz)
          ERROR_OUT(BUFFER_ERROR, exit_dch);
  
@@ -79,7 +80,7 @@ index 658b742f5ed..dc09a179bf3 100644
      /* RFC 9147 Section 5.3: DTLS 1.3 ServerHello must have empty
       * legacy_session_id_echo. Don't store the client's value so it
       * won't be echoed in SendTls13ServerHello. */
-@@ -8064,7 +8071,7 @@ int SendTls13ServerHello(WOLFSSL* ssl, byte extMsgType)
+@@ -8058,7 +8065,7 @@ int SendTls13ServerHello(WOLFSSL* ssl, byte extMsgType)
      WOLFSSL_BUFFER(ssl->arrays->serverRandom, RAN_LEN);
  #endif
  
@@ -89,10 +90,10 @@ index 658b742f5ed..dc09a179bf3 100644
          /* RFC 9147 Section 5.3: DTLS 1.3 ServerHello must have empty
           * legacy_session_id_echo. */
 
-From baed98e35559c97dd78c06989622fd555a16172f Mon Sep 17 00:00:00 2001
+From 7592b481e75c169b9fc84cabf355f9517907f9de Mon Sep 17 00:00:00 2001
 From: Marco Oliverio <marco@wolfssl.com>
 Date: Mon, 18 May 2026 09:31:13 +0200
-Subject: [PATCH 2/2] test: dtls: add WOLFSSL_DTLS13_5_9_0_COMPAT related tests
+Subject: [PATCH 2/6] test: dtls: add WOLFSSL_DTLS13_5_9_0_COMPAT related tests
 
 ---
  tests/api/test_dtls.c | 141 +++++++++++++++++++++++++++++++++++++++---
@@ -294,3 +295,142 @@ index ee399fbe989..96e524b5372 100644
 +        TEST_DECL_GROUP("dtls", test_dtls13_oversized_cert_chain),             \
 +        TEST_DECL_GROUP("dtls", test_dtls13_5_9_0_compat)
  #endif /* TESTS_API_DTLS_H */
+
+From e6fa789e68287bab48fdd7ba55db1ba8a56c2e5d Mon Sep 17 00:00:00 2001
+From: Marco Oliverio <marco@wolfssl.com>
+Date: Tue, 19 May 2026 08:34:27 +0200
+Subject: [PATCH 3/6] test_dtls: remove non-ASCII chars
+
+---
+ tests/api/test_dtls.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tests/api/test_dtls.c b/tests/api/test_dtls.c
+index a4a2603a1d8..febee9dfaa6 100644
+--- a/tests/api/test_dtls.c
++++ b/tests/api/test_dtls.c
+@@ -3070,7 +3070,7 @@ int test_dtls13_5_9_0_compat(void)
+ 
+     ExpectNotNull(sess = wolfSSL_get1_session(ssl_c));
+ 
+-    /* Force a non-zero session ID — simulates a wolfSSL <=v5.9.0 client that
++    /* Force a non-zero session ID - simulates a wolfSSL <=v5.9.0 client that
+      * mistakenly sends 32 bytes as legacy_session_id in DTLS 1.3. */
+     if (sess != NULL && sess->sessionIDSz == 0) {
+         sess->sessionIDSz = ID_LEN;
+@@ -3114,7 +3114,7 @@ int test_dtls13_5_9_0_compat(void)
+     ExpectIntEQ(test_ctx.c_buff[DTLS_RECORD_HEADER_SZ +
+         DTLS_HANDSHAKE_HEADER_SZ + OPAQUE16_LEN + RAN_LEN], ID_LEN);
+ 
+-    /* Complete the handshake — Finished MAC validates the transcript */
++    /* Complete the handshake - Finished MAC validates the transcript */
+     ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+ 
+     wolfSSL_free(ssl_c); ssl_c = NULL;
+@@ -3146,7 +3146,7 @@ int test_dtls13_5_9_0_compat(void)
+     ExpectIntEQ(test_ctx.c_buff[DTLS_RECORD_HEADER_SZ +
+         DTLS_HANDSHAKE_HEADER_SZ + OPAQUE16_LEN + RAN_LEN], ID_LEN);
+ 
+-    /* Complete the handshake — Finished MAC validates RestartHandshakeHashWithCookie */
++    /* Complete the handshake - Finished MAC validates RestartHandshakeHashWithCookie */
+     ExpectIntEQ(test_memio_do_handshake(ssl_c, ssl_s, 10, NULL), 0);
+ 
+     wolfSSL_SESSION_free(sess);
+
+From bc574f793067990a7bbcc085c70a54dfcd0dab3d Mon Sep 17 00:00:00 2001
+From: Marco Oliverio <marco@wolfssl.com>
+Date: Tue, 26 May 2026 08:42:15 +0200
+Subject: [PATCH 5/6] dtls13: WOLFSSL_DTLS13_5_9_0_COMPAT ->
+ WOLFSSL_DTLS13_ECHO_LEGACY_SESSION_ID
+
+---
+ .wolfssl_known_macro_extras | 2 +-
+ src/dtls.c                  | 2 +-
+ src/tls13.c                 | 8 ++++----
+ tests/api/test_dtls.c       | 6 +++---
+ 4 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/src/dtls.c b/src/dtls.c
+index a22b5768bb2..ef8a5f9ef71 100644
+--- a/src/dtls.c
++++ b/src/dtls.c
+@@ -860,7 +860,7 @@ static int SendStatelessReplyDtls13(const WOLFSSL* ssl, WolfSSL_CH* ch)
+         nonConstSSL->options.tls1_1 = 1;
+         nonConstSSL->options.tls1_3 = 1;
+ 
+-#ifdef WOLFSSL_DTLS13_5_9_0_COMPAT
++#ifdef WOLFSSL_DTLS13_ECHO_LEGACY_SESSION_ID
+         nonConstSSL->session->sessionIDSz = (byte)ch->sessionId.size;
+         if (ch->sessionId.size > 0)
+             XMEMCPY(nonConstSSL->session->sessionID, ch->sessionId.elements,
+diff --git a/src/tls13.c b/src/tls13.c
+index 174b0d4684d..8138eb426b0 100644
+--- a/src/tls13.c
++++ b/src/tls13.c
+@@ -5776,7 +5776,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+         /* RFC 9147 Section 5.3 / RFC 9001 Section 8.4: DTLS 1.3 and QUIC
+          * ServerHello must have empty legacy_session_id_echo. */
+         int requireEmptyEcho = 1;
+-#ifdef WOLFSSL_DTLS13_5_9_0_COMPAT
++#ifdef WOLFSSL_DTLS13_ECHO_LEGACY_SESSION_ID
+         /* Compat: a wolfSSL <= 5.9.0 DTLS 1.3 server echoes the client's
+          * legacy_session_id; accept any echo. */
+         if (ssl->options.dtls)
+@@ -6980,7 +6980,7 @@ static int RestartHandshakeHashWithCookie(WOLFSSL* ssl, Cookie* cookie)
+ 
+     /* Reconstruct the HelloRetryMessage for handshake hash. */
+     sessIdSz = ssl->session->sessionIDSz;
+-#if defined(WOLFSSL_DTLS13) && !defined(WOLFSSL_DTLS13_5_9_0_COMPAT)
++#if defined(WOLFSSL_DTLS13) && !defined(WOLFSSL_DTLS13_ECHO_LEGACY_SESSION_ID)
+     /* RFC 9147 Section 5.3: DTLS 1.3 must use empty legacy_session_id. */
+     if (ssl->options.dtls)
+         sessIdSz = 0;
+@@ -7460,7 +7460,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
+     if (sessIdSz + args->idx > helloSz)
+         ERROR_OUT(BUFFER_ERROR, exit_dch);
+ 
+-#if defined(WOLFSSL_DTLS13) && !defined(WOLFSSL_DTLS13_5_9_0_COMPAT)
++#if defined(WOLFSSL_DTLS13) && !defined(WOLFSSL_DTLS13_ECHO_LEGACY_SESSION_ID)
+     /* RFC 9147 Section 5.3: DTLS 1.3 ServerHello must have empty
+      * legacy_session_id_echo. Don't store the client's value so it
+      * won't be echoed in SendTls13ServerHello. */
+@@ -8065,7 +8065,7 @@ int SendTls13ServerHello(WOLFSSL* ssl, byte extMsgType)
+     WOLFSSL_BUFFER(ssl->arrays->serverRandom, RAN_LEN);
+ #endif
+ 
+-#if defined(WOLFSSL_DTLS13) && !defined(WOLFSSL_DTLS13_5_9_0_COMPAT)
++#if defined(WOLFSSL_DTLS13) && !defined(WOLFSSL_DTLS13_ECHO_LEGACY_SESSION_ID)
+     if (ssl->options.dtls) {
+         /* RFC 9147 Section 5.3: DTLS 1.3 ServerHello must have empty
+          * legacy_session_id_echo. */
+diff --git a/tests/api/test_dtls.c b/tests/api/test_dtls.c
+index febee9dfaa6..336f89257f9 100644
+--- a/tests/api/test_dtls.c
++++ b/tests/api/test_dtls.c
+@@ -2956,7 +2956,7 @@ int test_dtls13_no_session_id_echo(void)
+     EXPECT_DECLS;
+ #if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_DTLS13) && \
+     defined(HAVE_SESSION_TICKET) && defined(HAVE_ECC) && \
+-    !defined(WOLFSSL_DTLS13_5_9_0_COMPAT)
++    !defined(WOLFSSL_DTLS13_ECHO_LEGACY_SESSION_ID)
+     struct test_memio_ctx test_ctx;
+     WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+     WOLFSSL *ssl_c = NULL, *ssl_s = NULL;
+@@ -3032,14 +3032,14 @@ int test_dtls13_no_session_id_echo(void)
+     return EXPECT_RESULT();
+ }
+ 
+-/* Test that a server built with WOLFSSL_DTLS13_5_9_0_COMPAT echoes the
++/* Test that a server built with WOLFSSL_DTLS13_ECHO_LEGACY_SESSION_ID echoes the
+  * client's legacy_session_id in both the direct ServerHello path and the
+  * stateless HRR path (which also exercises RestartHandshakeHashWithCookie). */
+ int test_dtls13_5_9_0_compat(void)
+ {
+     EXPECT_DECLS;
+ #if defined(HAVE_MANUAL_MEMIO_TESTS_DEPENDENCIES) && defined(WOLFSSL_DTLS13) && \
+-    defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_DTLS13_5_9_0_COMPAT) && \
++    defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_DTLS13_ECHO_LEGACY_SESSION_ID) && \
+     defined(HAVE_ECC)
+     struct test_memio_ctx test_ctx;
+     WOLFSSL_CTX *ctx_c = NULL, *ctx_s = NULL;
+

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl"
-version = "7.1.0"
+version = "7.2.0"
 description = "High-level bindings for WolfSSL"
 authors.workspace = true
 license.workspace = true
@@ -29,7 +29,7 @@ unnecessary_safety_comment = "deny"
 bytes = "1"
 log = "0.4"
 thiserror = "2.0"
-wolfssl-sys = { path = "../wolfssl-sys", version = "4.1.0" }
+wolfssl-sys = { path = "../wolfssl-sys", version = "4.2.0" }
 
 [dev-dependencies]
 async-trait = "0.1.73"


### PR DESCRIPTION
PR https://github.com/expressvpn/wolfssl-rs/pull/363 has been done before the upstream PR is merged and there were some changes in the upstream before merging.

So update our patch to reflect the exact changes.

Primarily renaming cflag in build.rs from WOLFSSL_DTLS13_5_9_0_COMPAT to WOLFSSL_DTLS13_ECHO_LEGACY_SESSION_ID.

**Changes**

Pull PR10492 head (6 commits, mailbox format), then trim:
- drop .wolfssl_known_macro_extras hunks (PATCH 1, 5) and entire PATCH 4/6 (revert pair) — that file's surrounding context does not exist in 5.9.1.
- rewrite test_dtls.h hunks in PATCH 2 to drop test_dtls_set_session_min_downgrade refs (also not in 5.9.1).
- space-prefix bare empty context lines so 'git apply' (Windows path in build.rs) accepts them.

