### PR TITLE
build: default Apple deployment targets to rustc's deployment target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "wolfssl-sys"
-version = "4.2.1"
+version = "4.3.0"
 dependencies = [
  "autotools",
  "bindgen",

--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-sys"
-version = "4.2.1"
+version = "4.3.0"
 description = "System bindings for WolfSSL"
 readme = "README.md"
 authors.workspace = true

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -216,6 +216,55 @@ fn apply_patch(wolfssl_path: &Path, patch: impl AsRef<Path>) -> Result<(), Strin
 }
 
 /**
+ * Resolve the Apple deployment target (minimum supported OS version) for the current build.
+ *
+ * Uses the given environment variable when set — the standard override understood by
+ * clang, rustc and Xcode alike — otherwise falls back to rustc's own default deployment
+ * target for this target triple, so the C objects always match the minimum OS version of
+ * the Rust objects they are linked with.
+ */
+fn apple_deployment_target(env_var: &str) -> String {
+    println!("cargo:rerun-if-env-changed={env_var}");
+
+    match env::var(env_var) {
+        Ok(version) if !version.is_empty() => version,
+        _ => {
+            let rustc = env::var("RUSTC").unwrap_or_else(|_| String::from("rustc"));
+            let target = env::var("TARGET").unwrap();
+            let output = Command::new(&rustc)
+                .args(["--print", "deployment-target", "--target", &target])
+                .output()
+                .unwrap_or_else(|e| panic!("Failed to run {rustc}: {e}"));
+            if !output.status.success() {
+                panic!(
+                    "rustc --print deployment-target failed: {}\nSet {env_var} explicitly to work around this",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+
+            // Output looks like "MACOSX_DEPLOYMENT_TARGET=11.0"
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let version = stdout
+                .trim()
+                .split('=')
+                .nth(1)
+                .filter(|version| !version.is_empty())
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Unexpected rustc --print deployment-target output: {stdout:?}\nSet {env_var} explicitly to work around this"
+                    )
+                })
+                .to_string();
+
+            println!(
+                "cargo:warning={env_var} is not set; defaulting to rustc's deployment target {version} for {target}"
+            );
+            version
+        }
+    }
+}
+
+/**
  * Get Windows build configuration and platform based on build profile and target architecture
  */
 fn get_windows_build_params() -> (&'static str, &'static str) {
@@ -462,12 +511,12 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
     }
 
     if build_target::target_os() == build_target::Os::MacOS {
-        // Check whether we have set MACOSX_DEPLOYMENT_TARGET to ensure we support older MacOS
-        let deployment_target = env::var("MACOSX_DEPLOYMENT_TARGET")
-            .expect("Must have set minimum supported MacOS version (MACOSX_DEPLOYMENT_TARGET)");
-        if deployment_target.is_empty() {
-            panic!("MACOSX_DEPLOYMENT_TARGET is empty")
-        }
+        // Minimum supported MacOS version. Must be in the process env before conf.build():
+        // cc-rs reads it there when computing the -mmacosx-version-min= flag it bakes into
+        // the CFLAGS handed to configure (env vars on the configure/make processes are
+        // ignored in favour of that explicit flag).
+        let deployment_target = apple_deployment_target("MACOSX_DEPLOYMENT_TARGET");
+        env::set_var("MACOSX_DEPLOYMENT_TARGET", deployment_target);
 
         // Build options for MacOS
         let chost = match build_target::target_arch() {

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -564,12 +564,8 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
     }
 
     if build_target::target_os() == build_target::Os::TvOS {
-        // Check whether we have set TVOS_DEPLOYMENT_TARGET to ensure we support older tvOS
-        let ios_target = env::var("TVOS_DEPLOYMENT_TARGET")
-            .expect("Must have set minimum supported tvOS version");
-        if ios_target.is_empty() {
-            panic!("TVOS_DEPLOYMENT_TARGET is empty")
-        }
+        let deployment_target = apple_deployment_target("TVOS_DEPLOYMENT_TARGET");
+        env::set_var("TVOS_DEPLOYMENT_TARGET", deployment_target);
 
         // Build options for tvos
         let (chost, arch_flags, arch) = match build_target::target_arch() {

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -530,12 +530,8 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
     }
 
     if build_target::target_os() == build_target::Os::iOS {
-        // Check whether we have set IPHONEOS_DEPLOYMENT_TARGET to ensure we support older iOS
-        let ios_target = env::var("IPHONEOS_DEPLOYMENT_TARGET")
-            .expect("Must have set minimum supported iOS version (IPHONEOS_DEPLOYMENT_TARGET)");
-        if ios_target.is_empty() {
-            panic!("IPHONEOS_DEPLOYMENT_TARGET is empty")
-        }
+        let deployment_target = apple_deployment_target("IPHONEOS_DEPLOYMENT_TARGET");
+        env::set_var("IPHONEOS_DEPLOYMENT_TARGET", deployment_target);
 
         // Check if we are building for Mac Catalyst or iOS device
         let arm64_arch = if build_target::target_env()


### PR DESCRIPTION
## Why

Every consumer of `wolfssl-sys` on Apple platforms currently has to export `MACOSX_DEPLOYMENT_TARGET` / `IPHONEOS_DEPLOYMENT_TARGET` / `TVOS_DEPLOYMENT_TARGET` or the build panics. The panic was caution against a real hazard: with the variable unset, the C build would silently target whatever cc-rs falls back to — the Xcode SDK version (26.2 on current Xcode) or a hardcoded per-arch value. That fallback is machine-dependent and can exceed the minimum OS the Rust side links against, which means a binary that loads fine in testing but can call APIs that don't exist on older customer devices.

`rustc --print deployment-target` provides a default that is correct by construction: the C objects are built for the same minimum OS version as the Rust objects they are linked with, so the two halves of the binary can't disagree. With a safe default available, the env vars become optional overrides rather than a hard requirement — unchanged for our CI, which sets them explicitly — and an unset var now produces a visible `cargo:warning` naming the chosen value instead of a panic.

## How

- Resolve each deployment target as: env var if set, otherwise rustc's value for the target triple (plus a warning).
- Put the resolved value in the build script's process env before `conf.build()`. Verified empirically that this is the only channel that works: cc-rs reads it there and bakes `-m*-version-min=` into the CFLAGS handed to configure, and that explicit flag beats any env var the configure/make subprocesses see (`Config::env()`-only values never reach the compiled objects; checked via config.log and `otool -l` minos with distinct test values).
- Declare `cargo:rerun-if-env-changed` so changing a deployment target rebuilds the C library — previously this required a manual clean.

## Notes

- macOS was verified end-to-end locally (default, override, and rebuild-on-change paths); iOS/Catalyst/tvOS use the identical mechanism and are exercised by CI.
- `env::set_var` is safe under edition 2021; a move to edition 2024 would need a one-line `unsafe` wrap.