### PR TITLE
docs: point security policy bug bounty to YesWeHack

### DIFF
--- a/SECURITY.adoc
+++ b/SECURITY.adoc
@@ -9,10 +9,10 @@ program.
 === How to Submit a Report
 
 Researchers should submit their reports through
-https://bugcrowd.com/expressvpn[Bugcrowd]. Alternatively, we also accept
+https://yeswehack.com/programs/expressvpn-bug-bounty-program[YesWeHack]. Alternatively, we also accept
 submissions by email to security@expressvpn.com.
 
-*Please note:* ExpressVPN uses Bugcrowd to manage all bug bounty programs.
+*Please note:* ExpressVPN uses YesWeHack to manage all bug bounty programs.
 Submitting via email means that we will share your email address and share
-content with Bugcrowd for the purposes of triage, even if you aren’t a member
+content with YesWeHack for the purposes of triage, even if you aren’t a member
 of the platform.


### PR DESCRIPTION
Update SECURITY.adoc to point to YesWeHack instead of Bugcrowd