### PR TITLE
wolfssl-sys: Enable Windows x86_64 assembly speedups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "wolfssl"
-version = "7.4.0"
+version = "7.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "wolfssl-sys"
-version = "4.3.1"
+version = "4.4.0"
 dependencies = [
  "autotools",
  "bindgen",

--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-sys"
-version = "4.3.1"
+version = "4.4.0"
 description = "System bindings for WolfSSL"
 readme = "README.md"
 authors.workspace = true

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -41,6 +41,9 @@ fn copy_wolfssl(dest: &Path) -> std::io::Result<PathBuf> {
     copy_dir_recursive(src, &dest_dir)?;
 
     if build_target::target_os() == build_target::Os::Windows {
+        // The generated user_settings.h is assembled from these headers
+        println!("cargo:rerun-if-changed=windows");
+
         // Determine architecture-specific user_settings file
         let arch_settings = match build_target::target_arch() {
             build_target::Arch::X86_64 => "windows/user_settings-x86_64.h",

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -145,6 +145,7 @@ const PATCH_DIR: &str = "patches";
 const PATCHES: &[&str] = &[
     "CVPN-1945-Lower-max-mtu-for-DTLS-1.3-handshake-message.patch",
     "PR10492-DTLS13-backward-compatible.patch",
+    "PR11254-MSVC-pass-SP-defines-to-ml64.patch",
 ];
 const OPTIONAL_FEATURES: &[&str] = &["aesccm", "dh", "opensslall", "opensslextra", "psk"];
 const MACRO_FEATURES: &[(&str, &str)] = &[("ex_data", "HAVE_EX_DATA"), ("alpn", "HAVE_ALPN")];
@@ -300,17 +301,26 @@ fn build_win(wolfssl_src: &Path) -> PathBuf {
 
     let (configuration, platform) = get_windows_build_params();
 
-    msb.run(
-        wolfssl_src,
-        &[
-            ".\\wolfssl.vcxproj",
-            "-t:Build",
-            &format!("-p:Configuration={}", configuration),
-            &format!("-p:Platform={}", platform),
-            "-p:PlatformToolset=v143",
-        ],
-    )
-    .expect("Failed to build WolfSSL");
+    let mut args = vec![
+        ".\\wolfssl.vcxproj".to_string(),
+        "-t:Build".to_string(),
+        format!("-p:Configuration={}", configuration),
+        format!("-p:Platform={}", platform),
+        "-p:PlatformToolset=v143".to_string(),
+    ];
+
+    if build_target::target_arch() == build_target::Arch::X86_64 {
+        // Assemble only the opt-in SP sizes enabled in windows/user_settings-common.h
+        // (keep the two in sync). The vcxproj default (see the WolfSSLSpAsmDefs
+        // property added by the PR11254 patch) is the full superset, which adds
+        // ~54 KB of unreferenced SP_521/SP_1024 assembly to the whole-archive
+        // linked library.
+        args.push("-p:WolfSSLSpAsmDefs=/DWOLFSSL_SP_384 /DWOLFSSL_SP_4096".to_string());
+    }
+
+    let args: Vec<&str> = args.iter().map(String::as_str).collect();
+    msb.run(wolfssl_src, &args)
+        .expect("Failed to build WolfSSL");
     wolfssl_src.to_path_buf()
 }
 

--- a/wolfssl-sys/patches/PR11254-MSVC-pass-SP-defines-to-ml64.patch
+++ b/wolfssl-sys/patches/PR11254-MSVC-pass-SP-defines-to-ml64.patch
@@ -1,0 +1,98 @@
+From c4cd0160192b12b2b38da0d696bf66f02040f422 Mon Sep 17 00:00:00 2001
+From: Eric Blankenhorn <eric@wolfssl.com>
+Date: Wed, 26 Aug 2026 15:04:42 +0800
+Subject: [PATCH] MSVC: pass SP feature defines to ml64 for sp_x86_64_asm.asm
+
+Backport of https://github.com/wolfSSL/wolfssl/pull/11254 to v5.9.1.
+
+Adds a WolfSSLSpAsmDefs MSBuild property spliced into the ml64 command
+for sp_x86_64_asm.asm. The MASM file's P-384, P-521, 4096-bit and SAKKE
+1024 sections are opt-in (IFDEF), so without assembler-side defines a C
+build enabling WOLFSSL_SP_384/WOLFSSL_SP_4096 fails to link (LNK2001 on
+sp_384_*/sp_4096_*). The property defaults to the full superset so the
+assembly always provides a superset of what sp_x86_64.c can reference;
+build.rs trims it to the sizes actually enabled via
+-p:WolfSSLSpAsmDefs.
+
+Backport notes: the upstream commit is against master and also patches
+wolfssl-VS2022.vcxproj, the FIPS projects, the CSharp wrapper and
+IDE/WIN/user_settings.h. This backport is limited to wolfssl.vcxproj,
+the only project wolfssl-sys builds: the upstream PropertyGroup hunks
+assume master-only context (WolfSSLIntelAsm), wolfssl-VS2022.vcxproj is
+committed with CRLF line endings (which this repository's gitattributes
+would corrupt in a patch), and build.rs overwrites
+IDE/WIN/user_settings.h with generated settings before patches apply.
+Drop this patch when the wolfSSL submodule is bumped past the PR.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+---
+ wolfssl.vcxproj | 31 +++++++++++++++++++++++--------
+ 1 file changed, 23 insertions(+), 8 deletions(-)
+
+diff --git a/wolfssl.vcxproj b/wolfssl.vcxproj
+index 58410b1..26646e0 100644
+--- a/wolfssl.vcxproj
++++ b/wolfssl.vcxproj
+@@ -56,6 +56,21 @@
+     <Keyword>Win32Proj</Keyword>
+   </PropertyGroup>
+   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
++  <PropertyGroup Label="WolfSSLSpAsm">
++    <!-- Feature macros the single precision (SP) x86_64 assembly is guarded by.
++         ml64.exe cannot read user_settings.h, so every opt-in IFDEF section of
++         wolfcrypt\src\sp_x86_64_asm.asm has to be enabled on the assembler
++         command line instead.  RSA/DH 2048 and 3072 and ECC P-256 are always
++         assembled; ECC P-384, ECC P-521, RSA/DH 4096 and SAKKE 1024 are opt in
++         and are turned on here so the assembly always provides a superset of
++         what the C compile of sp_x86_64.c can reference.  A section assembled
++         but not enabled for the C build is simply unreferenced code, while a
++         section the C build enables but that is missing here is an unresolved
++         external at link time (LNK2001 on sp_384_*, sp_521_*, sp_4096_* or
++         sp_1024_*).  Trim the list for a smaller library, e.g.:
++             msbuild /p:WolfSSLSpAsmDefs="/DWOLFSSL_SP_384" -->
++    <WolfSSLSpAsmDefs Condition="'$(WolfSSLSpAsmDefs)'==''">/DWOLFSSL_SP_384 /DWOLFSSL_SP_521 /DWOLFSSL_SP_4096 /DWOLFSSL_SP_1024</WolfSSLSpAsmDefs>
++  </PropertyGroup>
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+     <ConfigurationType>StaticLibrary</ConfigurationType>
+     <PlatformToolset>v110</PlatformToolset>
+@@ -479,14 +494,14 @@
+     <CustomBuild Include="wolfcrypt\src\aes_asm.asm">
+       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
+       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='DLL Debug|x64'">false</ExcludedFromBuild>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">ml64.exe /c /Zi /Fo"$(OutDir)%(Filename).obj" %(Identity)</Command>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='DLL Debug|x64'">ml64.exe /c /Zi /Fo"$(IntDir)%(Filename).obj" %(Identity)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">ml64.exe $(WolfSSLSpAsmDefs) /c /Zi /Fo"$(OutDir)%(Filename).obj" %(Identity)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='DLL Debug|x64'">ml64.exe $(WolfSSLSpAsmDefs) /c /Zi /Fo"$(IntDir)%(Filename).obj" %(Identity)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)%(Filename).obj</Outputs>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='DLL Debug|x64'">$(IntDir)%(Filename).obj</Outputs>
+       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
+       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='DLL Release|x64'">false</ExcludedFromBuild>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">ml64.exe /c /Zi /Fo"$(OutDir)%(Filename).obj" %(Identity)</Command>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='DLL Release|x64'">ml64.exe /c /Zi /Fo"$(IntDir)%(Filename).obj" %(Identity)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">ml64.exe $(WolfSSLSpAsmDefs) /c /Zi /Fo"$(OutDir)%(Filename).obj" %(Identity)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='DLL Release|x64'">ml64.exe $(WolfSSLSpAsmDefs) /c /Zi /Fo"$(IntDir)%(Filename).obj" %(Identity)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)%(Filename).obj</Outputs>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='DLL Release|x64'">$(IntDir)%(Filename).obj</Outputs>
+     </CustomBuild>
+@@ -549,14 +564,14 @@
+     <CustomBuild Include="wolfcrypt\src\sp_x86_64_asm.asm">
+       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
+       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='DLL Debug|x64'">false</ExcludedFromBuild>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">ml64.exe /c /Zi /Fo"$(OutDir)%(Filename).obj" %(Identity)</Command>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='DLL Debug|x64'">ml64.exe /c /Zi /Fo"$(IntDir)%(Filename).obj" %(Identity)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">ml64.exe $(WolfSSLSpAsmDefs) /c /Zi /Fo"$(OutDir)%(Filename).obj" %(Identity)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='DLL Debug|x64'">ml64.exe $(WolfSSLSpAsmDefs) /c /Zi /Fo"$(IntDir)%(Filename).obj" %(Identity)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)%(Filename).obj</Outputs>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='DLL Debug|x64'">$(IntDir)%(Filename).obj</Outputs>
+       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
+       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='DLL Release|x64'">false</ExcludedFromBuild>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">ml64.exe /c /Zi /Fo"$(OutDir)%(Filename).obj" %(Identity)</Command>
+-      <Command Condition="'$(Configuration)|$(Platform)'=='DLL Release|x64'">ml64.exe /c /Zi /Fo"$(IntDir)%(Filename).obj" %(Identity)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">ml64.exe $(WolfSSLSpAsmDefs) /c /Zi /Fo"$(OutDir)%(Filename).obj" %(Identity)</Command>
++      <Command Condition="'$(Configuration)|$(Platform)'=='DLL Release|x64'">ml64.exe $(WolfSSLSpAsmDefs) /c /Zi /Fo"$(IntDir)%(Filename).obj" %(Identity)</Command>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)%(Filename).obj</Outputs>
+       <Outputs Condition="'$(Configuration)|$(Platform)'=='DLL Release|x64'">$(IntDir)%(Filename).obj</Outputs>
+     </CustomBuild>
+-- 
+2.55.0.windows.5
+

--- a/wolfssl-sys/windows/user_settings-x86_64.h
+++ b/wolfssl-sys/windows/user_settings-x86_64.h
@@ -10,6 +10,27 @@
 #undef USE_INTEL_SPEEDUP
 // #define USE_INTEL_SPEEDUP // Needs ASM stubs which are not included in the vxproj
 
+// AVX1/AVX2 AES-GCM paths in aes_gcm_asm.asm; selected at runtime via cpuid
+#undef HAVE_INTEL_AVX1
+#define HAVE_INTEL_AVX1
+
+#undef HAVE_INTEL_AVX2
+#define HAVE_INTEL_AVX2
+
+// AVX/AVX2 ChaCha20 (chacha_asm.asm) and Poly1305 (poly1305_asm.asm)
+#undef USE_INTEL_CHACHA_SPEEDUP
+#define USE_INTEL_CHACHA_SPEEDUP
+
+#undef USE_INTEL_POLY1305_SPEEDUP
+#define USE_INTEL_POLY1305_SPEEDUP
+
+// Assembly single-precision math for RSA/ECC (sp_x86_64_asm.asm)
+#undef WOLFSSL_SP_ASM
+#define WOLFSSL_SP_ASM
+
+#undef WOLFSSL_SP_X86_64_ASM
+#define WOLFSSL_SP_X86_64_ASM
+
 #undef WOLFSSL_X86_64_BUILD
 #define WOLFSSL_X86_64_BUILD
 

--- a/wolfssl/Cargo.toml
+++ b/wolfssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl"
-version = "7.4.0"
+version = "7.5.0"
 description = "High-level bindings for WolfSSL"
 authors.workspace = true
 license.workspace = true
@@ -29,7 +29,7 @@ unnecessary_safety_comment = "deny"
 bytes = "1"
 log = "0.4"
 thiserror = "2.0"
-wolfssl-sys = { path = "../wolfssl-sys", version = "4.3.0" }
+wolfssl-sys = { path = "../wolfssl-sys", version = "4.4.0" }
 
 [dev-dependencies]
 async-trait = "0.1.73"


### PR DESCRIPTION
Enable the x64 MASM assembly in the Windows build. `wolfssl.vcxproj` already
assembles all six MASM files, but none of the macros that make the C code call
them were defined:

- `WOLFSSL_SP_ASM` + `WOLFSSL_SP_X86_64_ASM` — assembly SP math for RSA/ECC
- `USE_INTEL_CHACHA_SPEEDUP` + `USE_INTEL_POLY1305_SPEEDUP` — AVX/AVX2 ChaCha20-Poly1305
- `HAVE_INTEL_AVX1/AVX2` — AVX AES-GCM (previously SSE AESNI only)

All paths dispatch at runtime via cpuid. `USE_INTEL_SPEEDUP` stays off: it pulls
in SHA-2 assembly with no MASM port in wolfSSL v5.9.1; revisit on the next bump.

Included a PR fix from WolfSSL team for link failure when we build SP_ASM with SP_4096/384: wolfSSL/wolfssl#11254

Also in this PR:
- `build.rs` declares `cargo:rerun-if-changed=windows` — user_settings edits previously reused stale libraries silently
- GCM table GHASH variants benchmarked and rejected; numbers recorded in `user_settings-common.h`
- Version bump: wolfssl-sys 4.4.0, wolfssl 7.5.0

Verified: full wolfssl + wolfssl-sys test suites pass on ARM64 Windows (129 tests); full wolfCrypt self-test passes on x64.

## Performance: x64 Windows before/after

wolfCrypt benchmark (`benchmark.exe`, Release x64, MSVC), Intel i7-1165G7.
Medians of 5 interleaved runs per variant, pinned to one core.
**Before** = branch parent (C fallbacks). **After** = this PR (SP/AVX assembly enabled,
`sp_x86_64_asm.asm` link fix from wolfSSL/wolfssl#11254, ml64 defines trimmed to SP_384/SP_4096).

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| RSA-2048 private | 156 ops/s | 1,952 ops/s | **12.5×** |
| RSA-2048 public | 7,970 ops/s | 61,997 ops/s | **7.8×** |
| ECDSA P-256 sign | 6,562 ops/s | 53,465 ops/s | **8.1×** |
| ECDSA P-256 verify | 3,463 ops/s | 18,500 ops/s | **5.3×** |
| ECDHE P-256 agree | 3,577 ops/s | 22,348 ops/s | **6.2×** |
| ECDSA P-384 sign | 2,217 ops/s | 17,466 ops/s | **7.9×** |
| ECDSA P-384 verify | 1,083 ops/s | 5,751 ops/s | **5.3×** |
| ECDHE P-384 agree | 1,208 ops/s | 6,314 ops/s | **5.2×** |
| ChaCha20 | 465 MiB/s | 3,057 MiB/s | **6.6×** |
| Poly1305 | 1,302 MiB/s | 6,634 MiB/s | **5.1×** |
| ChaCha20-Poly1305 AEAD | 341 MiB/s | 2,029 MiB/s | **5.9×** |
| AES-GCM (128/192/256, enc+dec) | 5.0–5.8 GiB/s | 5.6–6.3 GiB/s | +1–15% |

Controls (AES-CBC, SHA-256, GMAC) were flat within run noise (−2.5%…+6%), so the deltas are attributable to the enabled assembly. AES-GCM is the noisiest family: its gain (AVX vs SSE AESNI) is real but small next to the public-key and ChaCha20-Poly1305 wins. Full wolfCrypt self-test passes on both variants.