### PR TITLE
wolfssl-sys: Use the NDK archiver for Android builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,11 +795,12 @@ dependencies = [
 
 [[package]]
 name = "wolfssl-sys"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "autotools",
  "bindgen",
  "build-target",
+ "cc",
  "msbuild",
  "test-case",
 ]

--- a/wolfssl-sys/Cargo.toml
+++ b/wolfssl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfssl-sys"
-version = "4.3.0"
+version = "4.3.1"
 description = "System bindings for WolfSSL"
 readme = "README.md"
 authors.workspace = true
@@ -15,6 +15,7 @@ edition.workspace = true
 bindgen = "0.72"
 autotools = "0.2"
 build-target = "0.8.0"
+cc = "1"
 
 [target.'cfg(windows)'.build-dependencies]
 msbuild = "0.2.0"

--- a/wolfssl-sys/build.rs
+++ b/wolfssl-sys/build.rs
@@ -503,6 +503,13 @@ fn build_wolfssl(wolfssl_src: &Path) -> PathBuf {
         conf.env("ARCH", arch);
         conf.env("CONFIGURE_PLATFORM", configure_platform);
 
+        // Configure falls back to the host `ar`/`ranlib` when the `<triplet>-`prefixed
+        // ones are missing, as they are in modern NDKs. On macOS that picks Xcode's,
+        // which cannot index ELF and silently leaves `libwolfssl.a` an empty archive.
+        let cc_build = cc::Build::new();
+        conf.env("AR", cc_build.get_archiver().get_program());
+        conf.env("RANLIB", cc_build.get_ranlib().get_program());
+
         // General Android specific configurations
         conf.disable("crypttests", None);
         conf.cflag("-DFP_MAX_BITS=8192");


### PR DESCRIPTION
Autotools' configure looks for `<host-triplet>-ar`/`-ranlib` and otherwise falls back to the unprefixed host tools. Modern NDKs ship neither, so on a macOS host configure settles for Xcode's `ar`/`ranlib`, which cannot index ELF objects and leaves `libwolfssl.a` a 96-byte empty archive. Nothing fails: the archive is bundled into the rlib, the cdylib links with every `wolfSSL_*` symbol undefined, and the breakage only surfaces at dlopen.

Pass configure the archiver cc-rs resolves, which is the same resolution already used for CC — `AR_<triple>`/`RANLIB_<triple>` when the caller sets them (cargo-ndk does), else the NDK's `llvm-ar`/`llvm-ranlib`.

Linux hosts were unaffected because GNU ranlib indexes ELF fine, which is why CI never caught it.