### PR TITLE
[CVPN-2620] release flow hardening

### DIFF
--- a/.github/scripts/get-crate-max-version.js
+++ b/.github/scripts/get-crate-max-version.js
@@ -1,0 +1,13 @@
+const axios = require('axios');
+
+async function get_crate_max_version(name) {
+  try {
+    const resp = await axios(`https://crates.io/api/v1/crates/${name}`);
+    return resp.data.crate.max_version;
+  } catch (error) {
+    console.error(`Error fetching crate details for ${name}:`, error.message);
+    throw error;
+  }
+}
+
+module.exports = get_crate_max_version;

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
       - name: Run +${{ matrix.target }} on Earthly
         run: earthly --ci +${{ matrix.target }}
   coverage:
@@ -55,6 +56,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
       - name: Run +run-coverage on Earthly
         id: coverage
         run: |
@@ -150,6 +152,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
             submodules: true
+            persist-credentials: false
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Setup Xcode ${{ env.XCODE_VERSION }}
@@ -168,6 +171,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
             submodules: true
+            persist-credentials: false
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Setup Rust toolchain
@@ -189,6 +193,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
             submodules: true
+            persist-credentials: false
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Setup Rust toolchain
@@ -212,6 +217,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
             submodules: true
+            persist-credentials: false
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Setup Rust toolchain
@@ -235,6 +241,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
             submodules: true
+            persist-credentials: false
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Setup Rust toolchain
@@ -275,6 +282,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress:  ${{ github.ref_name != 'main' }}
 
+permissions: {}
+
 env:
   RUST_VERSION: 1.98.0
   # We pin to a specific nightly Rust version (the one that eventually became $RUST_VERSION)
@@ -31,14 +33,16 @@ jobs:
       matrix:
         target: [run-tests, build-release, fmt, lint, check-dependencies, build-android-release, build-arm64, build-riscv64, test-riscv64]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       FORCE_COLOR: 1
     steps:
-      - uses: earthly/actions-setup@v1
+      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
         with:
           version: v0.8.3
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: true
           persist-credentials: false
@@ -46,14 +50,18 @@ jobs:
         run: earthly --ci +${{ matrix.target }}
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     env:
       FORCE_COLOR: 1
     steps:
-      - uses: earthly/actions-setup@v1
+      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
         with:
           version: v0.8.3
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: true
           persist-credentials: false
@@ -69,7 +77,7 @@ jobs:
           cat output/summary.txt  >> "$GITHUB_OUTPUT"
           echo ""                 >> "$GITHUB_OUTPUT"
           echo "$EOF"             >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage
           path: output/html
@@ -116,13 +124,13 @@ jobs:
           echo "Setting output: failed: $FAILED"
           echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
 
-      - uses: jwalton/gh-find-current-pr@v1
+      - uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
         id: find-pr
         with:
           state: open
       - name: Find Coverage Comment
         if: steps.find-pr.outputs.number
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: coverage-comment
         with:
           issue-number: ${{ steps.find-pr.outputs.number }}
@@ -130,7 +138,7 @@ jobs:
           body-includes: 'Code coverage summary'
       - name: Create or update comment
         if: steps.find-pr.outputs.number
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.coverage-comment.outputs.comment-id }}
           issue-number: ${{ steps.find-pr.outputs.number }}
@@ -148,15 +156,17 @@ jobs:
     env:
       MACOSX_DEPLOYMENT_TARGET: "11"
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
             submodules: true
             persist-credentials: false
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Setup Xcode ${{ env.XCODE_VERSION }}
-        uses: maxim-lobanov/setup-xcode@v1.6.0
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
       - name: Build on MacOS ARM64
@@ -167,20 +177,22 @@ jobs:
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.16"
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
             submodules: true
             persist-credentials: false
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: $RUST_VERSION
           target: x86_64-apple-darwin
       - name: Setup Xcode ${{ env.XCODE_VERSION }}
-        uses: maxim-lobanov/setup-xcode@v1.6.0
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
       - name: Build on MacOS ARM64
@@ -189,20 +201,22 @@ jobs:
     env:
       IPHONEOS_DEPLOYMENT_TARGET: '15.0'
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
             submodules: true
             persist-credentials: false
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: $RUST_VERSION
           target: aarch64-apple-ios, aarch64-apple-ios-sim, x86_64-apple-ios
       - name: Setup Xcode ${{ env.XCODE_VERSION }}
-        uses: maxim-lobanov/setup-xcode@v1.6.0
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
       - name: Build on iOS
@@ -213,20 +227,22 @@ jobs:
     env:
       TVOS_DEPLOYMENT_TARGET: '17.0'
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
             submodules: true
             persist-credentials: false
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: $RUST_NIGHTLY_VERSION
           components: rust-src
       - name: Setup Xcode ${{ env.XCODE_VERSION }}
-        uses: maxim-lobanov/setup-xcode@v1.6.0
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
       - name: Build on tvOS
@@ -237,20 +253,22 @@ jobs:
     env:
       IPHONEOS_DEPLOYMENT_TARGET: '13.1'
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
             submodules: true
             persist-credentials: false
       - name: Install automake
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf automake libtool
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: ${{ env.RUST_VERSION }}
           target: aarch64-apple-ios-macabi, x86_64-apple-ios-macabi
       - name: Setup Xcode ${{ env.XCODE_VERSION }}
-        uses: maxim-lobanov/setup-xcode@v1.6.0
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
       - name: Build on Mac Catalyst (ARM64)
@@ -278,18 +296,20 @@ jobs:
             os: windows-11-arm
             arch: arm64
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: true
           persist-credentials: false
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
         with:
           vs-version: '17'
       - name: Build on Windows (${{ matrix.arch }})

--- a/.github/workflows/nightly-cargo-deny.yaml
+++ b/.github/workflows/nightly-cargo-deny.yaml
@@ -11,4 +11,5 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
     - uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/nightly-cargo-deny.yaml
+++ b/.github/workflows/nightly-cargo-deny.yaml
@@ -4,12 +4,16 @@ on:
     - cron:  '24 12 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   cargo-deny:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         submodules: true
         persist-credentials: false
-    - uses: EmbarkStudios/cargo-deny-action@v2
+    - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1

--- a/.github/workflows/nightly-rust-update-check.yaml
+++ b/.github/workflows/nightly-rust-update-check.yaml
@@ -12,6 +12,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Import GPG Key
       uses: crazy-max/ghaction-import-gpg@v6

--- a/.github/workflows/nightly-rust-update-check.yaml
+++ b/.github/workflows/nightly-rust-update-check.yaml
@@ -4,18 +4,22 @@ on:
     - cron:  '09 1 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-for-updated-rust:
     runs-on: ubuntu-latest
     environment: expressvpn_iat_automation_githubiatuser_gpg_key
+    permissions:
+      contents: read
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         submodules: true
         persist-credentials: false
 
     - name: Import GPG Key
-      uses: crazy-max/ghaction-import-gpg@v6
+      uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
         passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -37,7 +41,7 @@ jobs:
     - name: Update Rust version in Github action
       run: sed -i -E 's/^(\s*RUST_VERSION:\s*)([0-9\.]+)$/\1${{ steps.check-version.outputs.rust }}/g' .github/workflows/ci.yaml
 
-    - uses: peter-evans/create-pull-request@v6
+    - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
       with:
         token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
         labels: ignore-release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,6 +100,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
 
       - name: Check Cargo.lock is up-to-date
         shell: bash
@@ -318,6 +319,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,19 +11,24 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
+permissions: {}
+
 jobs:
   check_label:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      issues: read
     outputs:
       is_ignore_release_labelled: ${{ steps.pr_labels.outputs.is_ignore_release_labelled }}
       issue_number: ${{ steps.pr_labels.outputs.issue_number }}
     steps:
-      - uses: jwalton/gh-find-current-pr@v1
+      - uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
         id: find_pr
         with:
           state: all
       - id: pr_labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           PR_NUMBER: ${{ steps.find_pr.outputs.pr }}
           EVENT_NUMBER: ${{ github.event.number }}
@@ -71,14 +76,17 @@ jobs:
     if: >-
       needs.check_label.outputs.is_ignore_release_labelled == 'true'
       && github.event_name == 'pull_request'
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      - uses: peter-evans/find-comment@v3
+      - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: fc
         with:
           issue-number: ${{ needs.check_label.outputs.issue_number }}
           comment-author: 'github-actions[bot]'
           body-includes: Release Plan
-      - uses: peter-evans/create-or-update-comment@v4
+      - uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ needs.check_label.outputs.issue_number }}
@@ -92,12 +100,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_label
     if: needs.check_label.outputs.is_ignore_release_labelled == 'false'
+    permissions:
+      contents: read
     outputs:
       is_dry_run: ${{ steps.compute_plan.outputs.is_dry_run }}
       publish_plan: ${{ steps.compute_plan.outputs.publish_plan }}
       table: ${{ steps.compute_plan.outputs.table }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: true
           persist-credentials: false
@@ -118,18 +128,18 @@ jobs:
 
       #   To uncomment once the versions on crates.io catches up to the latest version
       # - name: Check semver compliance
-      #   uses: obi1kenobi/cargo-semver-checks-action@v2
+      #   uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
       #   with:
       #     package: wolfssl-sys, wolfssl
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20.x'
       - run: npm ci --ignore-scripts
 
       - name: Pre-check version bumps
         id: pre_process_release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
             script: |
                 const toml = require('@iarna/toml');
@@ -179,7 +189,7 @@ jobs:
 
       - name: Compute publish plan
         id: compute_plan
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const is_merge_event = ${{ github.event_name == 'push' }}
@@ -309,25 +319,29 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check_label, plan]
     if: needs.check_label.outputs.is_ignore_release_labelled == 'false'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     env:
       FORCE_COLOR: 1
     steps:
-      - uses: earthly/actions-setup@v1
+      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
         with:
           version: v0.8.3
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: true
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20.x'
       - run: npm ci --ignore-scripts
 
       - name: Publish crates sequentially
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         id: process_release
         env:
           CARGO_REGISTRY_TOKEN: "${{ secrets.CARGO_REGISTRY_TOKEN }}"
@@ -443,14 +457,14 @@ jobs:
                 }
             }
 
-      - uses: peter-evans/find-comment@v3
+      - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: fc
         with:
           issue-number: ${{ needs.check_label.outputs.issue_number }}
           comment-author: 'github-actions[bot]'
           body-includes: Release Plan
       - if: needs.plan.outputs.table == ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ needs.check_label.outputs.issue_number }}
@@ -460,7 +474,7 @@ jobs:
             Nothing to release
           edit-mode: replace
       - if: needs.plan.outputs.table != ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ needs.check_label.outputs.issue_number }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,18 +88,15 @@ jobs:
             :label: Release skipped — `ignore-release` label is applied.
           edit-mode: replace
 
-  release:
+  plan:
     runs-on: ubuntu-latest
     needs: check_label
     if: needs.check_label.outputs.is_ignore_release_labelled == 'false'
-    env:
-      CARGO_REGISTRY_TOKEN: "${{ secrets.CARGO_REGISTRY_TOKEN }}"
-      FORCE_COLOR: 1
+    outputs:
+      is_dry_run: ${{ steps.compute_plan.outputs.is_dry_run }}
+      publish_plan: ${{ steps.compute_plan.outputs.publish_plan }}
+      table: ${{ steps.compute_plan.outputs.table }}
     steps:
-      - uses: earthly/actions-setup@v1
-        with:
-          version: v0.8.3
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -177,23 +174,170 @@ jobs:
                     core.setFailed('No version bumps detected in wolfssl or wolfssl-sys. Either bump a version or add the "ignore-release" label to the PR.');
                 } else {
                     console.log(`Version bumps detected:\n${bump_details.join('\n')}`);
-                }                
+                }
+
+      - name: Compute publish plan
+        id: compute_plan
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const is_merge_event = ${{ github.event_name == 'push' }}
+
+            const NO_RELEASE = ':negative_squared_cross_mark: No release';
+            const RELEASE = ':white_check_mark: Release';
+
+            const toml = require('@iarna/toml');
+            const fs = require('fs');
+            const axios = require('axios');
+            const compare_versions = require('compare-versions');
+
+            async function get_crate_max_version(name) {
+              try {
+                const resp = await axios(`https://crates.io/api/v1/crates/${name}`);
+                return resp.data.crate.max_version;
+              } catch(error) {
+                console.error(`Error fetching crate details for ${name}:`, error.message);
+                throw error;
+              }
+            }
+
+            const is_dry_run = !is_merge_event;
+            console.log("Dry run:", is_dry_run);
+
+            // Strict publish order: wolfssl-sys first, then wolfssl
+            // because wolfssl is dependent on wolfssl-sys
+            const publish_order = [
+                { toml_path: 'wolfssl-sys/Cargo.toml' },
+                { toml_path: 'wolfssl/Cargo.toml' },
+            ];
+
+            const results = [];
+            const publish_plan = [];
+            let sys_needs_publishing = false;
+
+            for (const entry of publish_order) {
+                const data = toml.parse(fs.readFileSync(entry.toml_path, 'utf8'));
+                const name = data.package.name;
+                const version_on_file = data.package.version;
+                const version_on_crate_io = await get_crate_max_version(name);
+                const is_wolfssl = name === 'wolfssl';
+
+                // Check if version is lower than crates.io
+                if (compare_versions.compare(version_on_file, version_on_crate_io, '<')) {
+                    core.setFailed(`${name} version ${version_on_file} is lower than crates.io ${version_on_crate_io}`);
+                    return;
+                }
+
+                // Check version is equals crates.io
+                if (compare_versions.compare(version_on_file, version_on_crate_io, '=')) {
+                    console.log(`${name}@${version_on_file} already published, skipping`);
+                    results.push({ name, version_on_file, version_on_crate_io, release_status: NO_RELEASE, comment: "already published" });
+                    continue;
+                }
+
+                // Version is greater than crates.io, continue processing release
+                console.log(`${name}: ${version_on_crate_io} → ${version_on_file}`);
+
+                // For wolfssl: validate dependency on wolfssl-sys
+                if (is_wolfssl) {
+                    const sys_data = toml.parse(fs.readFileSync('wolfssl-sys/Cargo.toml', 'utf8'));
+                    const sys_version = sys_data.package.version;
+
+                    // To check wolfssl-sys dependency version inside wolfssl/Cargo.toml
+                    const dep_entry = data.dependencies?.['wolfssl-sys'];
+                    let dep_version;
+                    if (typeof dep_entry === 'string') {
+                        // wolfssl-sys = 3.0.0
+                        dep_version = dep_entry;
+                    } else {
+                        // wolfssl-sys = { path = "../wolfssl-sys", version = "x.y.z" }
+                        dep_version = dep_entry?.version;
+                    }
+
+                    if (!dep_version) {
+                        core.setFailed('Could not read wolfssl-sys dependency version from wolfssl/Cargo.toml');
+                        return;
+                    }
+
+                    if (dep_version !== sys_version) {
+                        core.setFailed(`wolfssl depends on wolfssl-sys@${dep_version} but wolfssl-sys/Cargo.toml has version ${sys_version}. Update the dependency.`);
+                        return;
+                    }
+
+                    console.log(`Dependency check passed: wolfssl depends on wolfssl-sys@${dep_version}, matches wolfssl-sys/Cargo.toml`);
+
+                    // Get wolfssl-sys latest version on crates.io
+                    const live_sys_version = await get_crate_max_version('wolfssl-sys');
+
+                    // On real publish, verify wolfssl-sys is available on crates.io else skip if dry run.
+                    if (!is_dry_run) {
+                        if (live_sys_version !== sys_version) {
+                            core.setFailed(`wolfssl-sys@${sys_version} is not yet live on crates.io (found ${live_sys_version}). This should not happen.`);
+                            return;
+                        }
+                    }
+                } else {
+                    // For wolfssl-sys, update flag
+                    sys_needs_publishing = true;
+                }
+
+                // Comment for PR table
+                let comment = "";
+                // If both wolfssl and wolfssl-sys being published
+                if (is_wolfssl && sys_needs_publishing) {
+                    comment = "after wolfssl-sys";
+                }
+
+                results.push({ name, version_on_file, version_on_crate_io, release_status: RELEASE, comment });
+
+                // In dry-run mode, skip wolfssl publish if wolfssl-sys is also being published,
+                // because cargo publish --dry-run verifies deps against crates.io and wolfssl-sys
+                // won't be there yet.
+                const skip = is_wolfssl && is_dry_run && sys_needs_publishing;
+                publish_plan.push({ name, version_on_file, skip });
+            }
+
+            const crates_to_publish_table_rendered = results.map(item =>
+            `| \`${item.name}\` | ${item.version_on_crate_io} | **${item.version_on_file}** | ${item.release_status} | ${item.comment} | `).join("\n");
+
+            core.setOutput('table', crates_to_publish_table_rendered);
+            core.setOutput('publish_plan', JSON.stringify(publish_plan));
+            core.setOutput('is_dry_run', String(is_dry_run));
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [check_label, plan]
+    if: needs.check_label.outputs.is_ignore_release_labelled == 'false'
+    env:
+      FORCE_COLOR: 1
+    steps:
+      - uses: earthly/actions-setup@v1
+        with:
+          version: v0.8.3
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - run: npm install axios
 
       - name: Publish crates sequentially
         uses: actions/github-script@v7
         id: process_release
+        env:
+          CARGO_REGISTRY_TOKEN: "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+          PUBLISH_PLAN: ${{ needs.plan.outputs.publish_plan }}
+          IS_DRY_RUN: ${{ needs.plan.outputs.is_dry_run }}
         with:
           script: |
-            const is_merge_event = ${{ github.event_name == 'push' }}
-            
-            const NO_RELEASE = ':negative_squared_cross_mark: No release';
-            const RELEASE = ':white_check_mark: Release';
-            
-            const toml = require('@iarna/toml');
-            const fs = require('fs');
             const axios = require('axios');
             const { spawn } = require('child_process');
-            const compare_versions = require('compare-versions');
+
+            const is_dry_run = process.env.IS_DRY_RUN === 'true';
+            const publish_plan = JSON.parse(process.env.PUBLISH_PLAN || '[]');
 
             async function get_crate_max_version(name) {
               try {
@@ -240,7 +384,7 @@ jobs:
 
                     await new Promise(r => setTimeout(r, interval_ms));
                 }
-                throw new Error(`Timed out waiting for ${name}@${version} on crates.io after ${timeoutMs / 1000}s`);
+                throw new Error(`Timed out waiting for ${name}@${version} on crates.io after ${timeout_ms / 1000}s`);
             }
 
             async function create_github_release(crate_name, version) {
@@ -278,100 +422,13 @@ jobs:
                 }
             }
 
-            const is_dry_run = !is_merge_event;
             console.log("Dry run:", is_dry_run);
 
-            // Strict publish order: wolfssl-sys first, then wolfssl
-            // because wolfssl is dependent on wolfssl-sys
-            const publish_order = [
-                { toml_path: 'wolfssl-sys/Cargo.toml' },
-                { toml_path: 'wolfssl/Cargo.toml' },
-            ];
+            for (const entry of publish_plan) {
+                const { name, version_on_file, skip } = entry;
 
-            const results = [];
-            let sys_needs_publishing = false;
-
-            for (const entry of publish_order) {
-                const data = toml.parse(fs.readFileSync(entry.toml_path, 'utf8'));
-                const name = data.package.name;
-                const version_on_file = data.package.version;
-                const version_on_crate_io = await get_crate_max_version(name);
-                const is_wolfssl = name === 'wolfssl';
-                
-                // Check if version is lower than crates.io
-                if (compare_versions.compare(version_on_file, version_on_crate_io, '<')) {
-                    core.setFailed(`${name} version ${version_on_file} is lower than crates.io ${version_on_crate_io}`);
-                    return;
-                }
-
-                // Check version is equals crates.io
-                if (compare_versions.compare(version_on_file, version_on_crate_io, '=')) {
-                    console.log(`${name}@${version_on_file} already published, skipping`);
-                    results.push({ name, version_on_file, version_on_crate_io, release_status: NO_RELEASE, comment: "already published" });
-                    continue;
-                }
-
-                // Version is greater than crates.io, continue processing release
-                console.log(`${name}: ${version_on_crate_io} → ${version_on_file}`);
-
-                // For wolfssl: validate dependency on wolfssl-sys
-                if (is_wolfssl) {
-                    const sys_data = toml.parse(fs.readFileSync('wolfssl-sys/Cargo.toml', 'utf8'));
-                    const sys_version = sys_data.package.version;
-                    
-                    // To check wolfssl-sys dependency version inside wolfssl/Cargo.toml
-                    const dep_entry = data.dependencies?.['wolfssl-sys'];
-                    let dep_version;
-                    if (typeof dep_entry === 'string') {
-                        // wolfssl-sys = 3.0.0
-                        dep_version = dep_entry;
-                    } else {
-                        // wolfssl-sys = { path = "../wolfssl-sys", version = "x.y.z" } 
-                        dep_version = dep_entry?.version;
-                    }
-                    
-                    if (!dep_version) {
-                        core.setFailed('Could not read wolfssl-sys dependency version from wolfssl/Cargo.toml');
-                        return;
-                    }
-                    
-                    if (dep_version !== sys_version) {
-                        core.setFailed(`wolfssl depends on wolfssl-sys@${dep_version} but wolfssl-sys/Cargo.toml has version ${sys_version}. Update the dependency.`);
-                        return;
-                    }
-                    
-                    console.log(`Dependency check passed: wolfssl depends on wolfssl-sys@${dep_version}, matches wolfssl-sys/Cargo.toml`);
-    
-                    // Get wolfssl-sys latest version on crates.io
-                    const live_sys_version = await get_crate_max_version('wolfssl-sys');
-                    
-                    // On real publish, verify wolfssl-sys is available on crates.io else skip if dry run.
-                    if (!is_dry_run) {
-                        if (live_sys_version !== sys_version) {
-                            core.setFailed(`wolfssl-sys@${sys_version} is not yet live on crates.io (found ${live_sys_version}). This should not happen.`);
-                            return;   
-                        }    
-                    }
-                } else {
-                    // For wolfssl-sys, update flag
-                    sys_needs_publishing = true;
-                }
-
-                // Comment for PR table
-                let comment = "";
-                // If both wolfssl and wolfssl-sys being published 
-                if (is_wolfssl && sys_needs_publishing) {
-                    comment = "after wolfssl-sys";
-                }
-
-                results.push({ name, version_on_file, version_on_crate_io, release_status: RELEASE, comment });
-                
-                // In dry-run mode, skip wolfssl publish if wolfssl-sys is also being published,
-                // because cargo publish --dry-run verifies deps against crates.io and wolfssl-sys
-                // won't be there yet.
-                const sys_publishing_with_wolf_in_dry_run = is_wolfssl && is_dry_run && sys_needs_publishing;
-                if (sys_publishing_with_wolf_in_dry_run) {
-                  console.log(`Skipping dry-run publish for wolfssl (wolfssl-sys not yet on crates.io)`);
+                if (skip) {
+                  console.log(`Skipping dry-run publish for ${name} (dependency not yet on crates.io)`);
                 } else {
                   await run_command(["earthly", "--push", "--ci", "--secret", "CARGO_REGISTRY_TOKEN", "+publish", `--PACKAGE=${name}`, `--DRY_RUN=${is_dry_run}`]);
                 }
@@ -384,17 +441,13 @@ jobs:
                 }
             }
 
-            const crates_to_publish_table_rendered = results.map(item =>
-            `| \`${item.name}\` | ${item.version_on_crate_io} | **${item.version_on_file}** | ${item.release_status} | ${item.comment} | `).join("\n");
-            core.setOutput('crates_to_publish_table_rendered', crates_to_publish_table_rendered);
-
       - uses: peter-evans/find-comment@v3
         id: fc
         with:
           issue-number: ${{ needs.check_label.outputs.issue_number }}
           comment-author: 'github-actions[bot]'
           body-includes: Release Plan
-      - if: steps.process_release.outputs.crates_to_publish_table_rendered == ''
+      - if: needs.plan.outputs.table == ''
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -404,7 +457,7 @@ jobs:
 
             Nothing to release
           edit-mode: replace
-      - if: steps.process_release.outputs.crates_to_publish_table_rendered != ''
+      - if: needs.plan.outputs.table != ''
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -414,5 +467,5 @@ jobs:
 
             | Crate | Previous version | New version | Release? | Comment |
             |--|--|--|--|--|
-            ${{ steps.process_release.outputs.crates_to_publish_table_rendered }}
+            ${{ needs.plan.outputs.table }}
           edit-mode: replace

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-      - run: npm install @iarna/toml axios compare-versions
+      - run: npm ci
 
       - name: Pre-check version bumps
         id: pre_process_release
@@ -322,7 +322,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-      - run: npm install axios
+      - run: npm ci
 
       - name: Publish crates sequentially
         uses: actions/github-script@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,7 +138,7 @@ jobs:
                 const fs = require('fs');
                 const axios = require('axios');
                 const compare_versions = require('compare-versions')
-                    
+
                 async function get_crate_max_version(name) {
                     try {
                         const resp = await axios(`https://crates.io/api/v1/crates/${name}`);
@@ -148,22 +148,22 @@ jobs:
                         throw error;
                     }
                 }
-                
+
                 const crates_to_check = ['wolfssl/Cargo.toml', 'wolfssl-sys/Cargo.toml']
                 let has_version_bump = false
                 const bump_details = []
-                
+
                 for (const crate_path of crates_to_check) {
                     const data = toml.parse(fs.readFileSync(crate_path, 'utf-8'))
                     const name = data.package.name
                     const version_on_file = data.package.version
                     const version_on_crate_io = await get_crate_max_version(name)
-                    
+
                     if (compare_versions.compare(version_on_file, version_on_crate_io, '<')) {
                         core.setFailed(`${name} version ${version_on_file} is lower than crates.io ${version_on_crate_io}`);
                         return;
                     }
-                    
+
                     if (compare_versions.compare(version_on_file, version_on_crate_io, '>')) {
                         console.log(`✓ ${name}: ${version_on_crate_io} → ${version_on_file}`);
                         bump_details.push(`${name}: ${version_on_crate_io} → ${version_on_file}`);
@@ -172,7 +172,7 @@ jobs:
                         console.log(`${name}: ${version_on_file} (unchanged)`);
                     }
                 }
-                
+
                 if (!has_version_bump) {
                     core.setFailed('No version bumps detected in wolfssl or wolfssl-sys. Either bump a version or add the "ignore-release" label to the PR.');
                 } else {
@@ -237,7 +237,7 @@ jobs:
                     } catch (e) {
                         console.log(`  Error checking crates.io: ${e.message}, retrying...`);
                     }
-                    
+
                     await new Promise(r => setTimeout(r, interval_ms));
                 }
                 throw new Error(`Timed out waiting for ${name}@${version} on crates.io after ${timeoutMs / 1000}s`);
@@ -375,7 +375,7 @@ jobs:
                 } else {
                   await run_command(["earthly", "--push", "--ci", "--secret", "CARGO_REGISTRY_TOKEN", "+publish", `--PACKAGE=${name}`, `--DRY_RUN=${is_dry_run}`]);
                 }
-    
+
                 if (!is_dry_run) {
                     // Polling for the published version to appear on crates.io
                     await wait_for_crates_io(name, version_on_file);

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - name: Pre-check version bumps
         id: pre_process_release
@@ -322,7 +322,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - name: Publish crates sequentially
         uses: actions/github-script@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -319,7 +319,7 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         id: process_release
         env:
-          CARGO_REGISTRY_TOKEN: "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+          CARGO_REGISTRY_TOKEN: ${{ needs.plan.outputs.is_dry_run == 'false' && secrets.CARGO_REGISTRY_TOKEN || '' }}
           PUBLISH_PLAN: ${{ needs.plan.outputs.publish_plan }}
           IS_DRY_RUN: ${{ needs.plan.outputs.is_dry_run }}
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,18 +138,8 @@ jobs:
             script: |
                 const toml = require('@iarna/toml');
                 const fs = require('fs');
-                const axios = require('axios');
                 const compare_versions = require('compare-versions')
-
-                async function get_crate_max_version(name) {
-                    try {
-                        const resp = await axios(`https://crates.io/api/v1/crates/${name}`);
-                        return resp.data.crate.max_version;
-                    } catch(error) {
-                        console.error(`Error fetching crate details for ${name}:`, error.message);
-                        throw error;
-                    }
-                }
+                const get_crate_max_version = require('./.github/scripts/get-crate-max-version.js');
 
                 const crates_to_check = ['wolfssl/Cargo.toml', 'wolfssl-sys/Cargo.toml']
                 let has_version_bump = false
@@ -194,18 +184,8 @@ jobs:
 
             const toml = require('@iarna/toml');
             const fs = require('fs');
-            const axios = require('axios');
             const compare_versions = require('compare-versions');
-
-            async function get_crate_max_version(name) {
-              try {
-                const resp = await axios(`https://crates.io/api/v1/crates/${name}`);
-                return resp.data.crate.max_version;
-              } catch(error) {
-                console.error(`Error fetching crate details for ${name}:`, error.message);
-                throw error;
-              }
-            }
+            const get_crate_max_version = require('./.github/scripts/get-crate-max-version.js');
 
             const is_dry_run = !is_merge_event;
             console.log("Dry run:", is_dry_run);
@@ -344,21 +324,11 @@ jobs:
           IS_DRY_RUN: ${{ needs.plan.outputs.is_dry_run }}
         with:
           script: |
-            const axios = require('axios');
             const { spawn } = require('child_process');
+            const get_crate_max_version = require('./.github/scripts/get-crate-max-version.js');
 
             const is_dry_run = process.env.IS_DRY_RUN === 'true';
             const publish_plan = JSON.parse(process.env.PUBLISH_PLAN || '[]');
-
-            async function get_crate_max_version(name) {
-              try {
-                const resp = await axios(`https://crates.io/api/v1/crates/${name}`);
-                return resp.data.crate.max_version;
-              } catch(error) {
-                console.error(`Error fetching crate details for ${name}:`, error.message);
-                throw error;
-              }
-            }
 
             function run_command(command_arr) {
                 return new Promise((resolve, reject) => {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,14 +14,18 @@ concurrency:
 permissions: {}
 
 jobs:
-  check_label:
+  plan:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
+      contents: read
     outputs:
       is_ignore_release_labelled: ${{ steps.pr_labels.outputs.is_ignore_release_labelled }}
       issue_number: ${{ steps.pr_labels.outputs.issue_number }}
+      is_dry_run: ${{ steps.compute_plan.outputs.is_dry_run }}
+      publish_plan: ${{ steps.compute_plan.outputs.publish_plan }}
+      table: ${{ steps.compute_plan.outputs.table }}
     steps:
       - uses: jwalton/gh-find-current-pr@f3d61b485d2801773f7a07b2aaa3306bd8f8e653 # v1.3.5
         id: find_pr
@@ -70,49 +74,36 @@ jobs:
             core.setOutput('is_ignore_release_labelled', is_ignore_release_labelled)
             core.setOutput('issue_number', issue_number)
 
-  skip_release:
-    runs-on: ubuntu-latest
-    needs: check_label
-    if: >-
-      needs.check_label.outputs.is_ignore_release_labelled == 'true'
-      && github.event_name == 'pull_request'
-    permissions:
-      issues: write
-      pull-requests: write
-    steps:
-      - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+      - if: >-
+          steps.pr_labels.outputs.is_ignore_release_labelled == 'true'
+          && github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: fc
         with:
-          issue-number: ${{ needs.check_label.outputs.issue_number }}
+          issue-number: ${{ steps.pr_labels.outputs.issue_number }}
           comment-author: 'github-actions[bot]'
           body-includes: Release Plan
-      - uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      - if: >-
+          steps.pr_labels.outputs.is_ignore_release_labelled == 'true'
+          && github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ needs.check_label.outputs.issue_number }}
+          issue-number: ${{ steps.pr_labels.outputs.issue_number }}
           body: |
             # :rocket: Release Plan
 
             :label: Release skipped — `ignore-release` label is applied.
           edit-mode: replace
 
-  plan:
-    runs-on: ubuntu-latest
-    needs: check_label
-    if: needs.check_label.outputs.is_ignore_release_labelled == 'false'
-    permissions:
-      contents: read
-    outputs:
-      is_dry_run: ${{ steps.compute_plan.outputs.is_dry_run }}
-      publish_plan: ${{ steps.compute_plan.outputs.publish_plan }}
-      table: ${{ steps.compute_plan.outputs.table }}
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - if: steps.pr_labels.outputs.is_ignore_release_labelled == 'false'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: true
           persist-credentials: false
 
-      - name: Check Cargo.lock is up-to-date
+      - if: steps.pr_labels.outputs.is_ignore_release_labelled == 'false'
+        name: Check Cargo.lock is up-to-date
         shell: bash
         run: |
           cargo update --workspace
@@ -132,12 +123,15 @@ jobs:
       #   with:
       #     package: wolfssl-sys, wolfssl
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - if: steps.pr_labels.outputs.is_ignore_release_labelled == 'false'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20.x'
-      - run: npm ci --ignore-scripts
+      - if: steps.pr_labels.outputs.is_ignore_release_labelled == 'false'
+        run: npm ci --ignore-scripts
 
-      - name: Pre-check version bumps
+      - if: steps.pr_labels.outputs.is_ignore_release_labelled == 'false'
+        name: Pre-check version bumps
         id: pre_process_release
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
@@ -187,7 +181,8 @@ jobs:
                     console.log(`Version bumps detected:\n${bump_details.join('\n')}`);
                 }
 
-      - name: Compute publish plan
+      - if: steps.pr_labels.outputs.is_ignore_release_labelled == 'false'
+        name: Compute publish plan
         id: compute_plan
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
@@ -317,8 +312,8 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: [check_label, plan]
-    if: needs.check_label.outputs.is_ignore_release_labelled == 'false'
+    needs: plan
+    if: needs.plan.outputs.is_ignore_release_labelled == 'false'
     permissions:
       contents: write
       issues: write
@@ -460,14 +455,14 @@ jobs:
       - uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: fc
         with:
-          issue-number: ${{ needs.check_label.outputs.issue_number }}
+          issue-number: ${{ needs.plan.outputs.issue_number }}
           comment-author: 'github-actions[bot]'
           body-includes: Release Plan
       - if: needs.plan.outputs.table == ''
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ needs.check_label.outputs.issue_number }}
+          issue-number: ${{ needs.plan.outputs.issue_number }}
           body: |
             # :rocket: Release Plan
 
@@ -477,7 +472,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ needs.check_label.outputs.issue_number }}
+          issue-number: ${{ needs.plan.outputs.issue_number }}
           body: |
             # :rocket: Release Plan
 

--- a/.github/workflows/weekly-cargo-update.yaml
+++ b/.github/workflows/weekly-cargo-update.yaml
@@ -12,6 +12,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Import GPG Key
       uses: crazy-max/ghaction-import-gpg@v6

--- a/.github/workflows/weekly-cargo-update.yaml
+++ b/.github/workflows/weekly-cargo-update.yaml
@@ -4,25 +4,31 @@ on:
     - cron:  '18 5 * * 1' # 5:18 AM UTC on Mondays
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   cargo-update:
     runs-on: ubuntu-latest
     environment: expressvpn_iat_automation_githubiatuser_gpg_key
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         submodules: true
         persist-credentials: false
 
     - name: Import GPG Key
-      uses: crazy-max/ghaction-import-gpg@v6
+      uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
         passphrase: ${{ secrets.GPG_PASSPHRASE }}
         git_user_signingkey: true
         git_commit_gpgsign: true
 
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
     - run: rustup show
 
     # Updates indirect and direct dependencies according to semver
@@ -58,7 +64,7 @@ jobs:
         echo "$body"           >> "$GITHUB_OUTPUT"
         echo "$EOF"            >> "$GITHUB_OUTPUT"
 
-    - uses: peter-evans/create-pull-request@v6
+    - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
       id: pr
       with:
         token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
@@ -108,7 +114,7 @@ jobs:
     # comment.
     - name: Outdated dependencies comment
       if: steps.pr.outputs.pull-request-number && steps.outdated-check.outputs.failed == 'true'
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
       with:
         issue-number: ${{ steps.pr.outputs.pull-request-number }}
         body: ${{ steps.outdated-check.outputs.comment }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 artifacts/
+/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,358 @@
+{
+  "name": "wolfssl-rs-release-tooling",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wolfssl-rs-release-tooling",
+      "dependencies": {
+        "@iarna/toml": "2.2.5",
+        "axios": "1.20.0",
+        "compare-versions": "6.1.1"
+      }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "wolfssl-rs-release-tooling",
+  "private": true,
+  "description": "Pinned dependencies for .github/workflows/release.yaml. Not a published package.",
+  "dependencies": {
+    "@iarna/toml": "2.2.5",
+    "axios": "1.20.0",
+    "compare-versions": "6.1.1"
+  }
+}


### PR DESCRIPTION
Harden the release workflow according to checklist:
[x] Move CARGO_REGISTRY_TOKEN out of job-level env; scope it to the single publish step only.

[x] Split pipeline: no-secret planning job (npm + TOML parsing) → separate publish job holding the token.

[x] Replace ad-hoc npm install with committed package.json + lockfile and npm ci; pin exact versions, or vendor the helper logic so nothing is resolved at release time.

[x] Use npm ci --ignore-scripts where lifecycle scripts aren't needed.

[x] Set persist-credentials: false on actions/checkout unless a later git-authenticated step needs it.

[x] Pin GitHub Actions by commit SHA; add minimal permissions: blocks.